### PR TITLE
feat: add partial renewal prompt and reminder capture

### DIFF
--- a/src/Landing/components/RenewModal.jsx
+++ b/src/Landing/components/RenewModal.jsx
@@ -7,6 +7,8 @@ import { Icon } from "@iconify/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { formatCurrency } from "../../utils/formatCurrency";
 import { fetchRenewalItems, fetchStates, fetchLGAs, initGuestRenewal } from "../../services/apiGuest";
+import { saveGuestDeferredReminders } from "../../services/apiDeferredReminders";
+import PartialRenewalPromptModal from "../../components/shared/PartialRenewalPromptModal";
 import { useNavigate } from "react-router-dom";
 
 export default function RenewModal({ isOpen, onClose, initialPlateNumber }) {
@@ -37,6 +39,8 @@ export default function RenewModal({ isOpen, onClose, initialPlateNumber }) {
 
   // Step 3 — gateway selection
   const [selectedGateway, setSelectedGateway] = useState("monicredit");
+  const [showPartialPrompt, setShowPartialPrompt] = useState(false);
+  const [pendingSkippedDocs, setPendingSkippedDocs] = useState([]);
 
   // Location data (loaded from backend)
   const [states, setStates] = useState([]);
@@ -195,6 +199,45 @@ export default function RenewModal({ isOpen, onClose, initialPlateNumber }) {
   // ── Step 2 → Step 3: advance to gateway selection ────────────────────────
   const handleProceedToPayment = () => {
     if (!isFormValid()) return;
+    const skipped = renewalItems
+      .filter((item) => !item.required && !selectedDocs.includes(item.id))
+      .map((item) => item.name);
+    if (skipped.length > 0) {
+      setPendingSkippedDocs(skipped);
+      setShowPartialPrompt(true);
+      return;
+    }
+    setStep(3);
+  };
+
+  const persistGuestDeferred = async (reminders) => {
+    if (!formData.email || !plateNumber || !Array.isArray(reminders) || reminders.length === 0) return;
+    try {
+      await saveGuestDeferredReminders({
+        guest_email: formData.email,
+        plate_number: plateNumber.replace(/\s+/g, "").toUpperCase(),
+        reminders,
+      });
+    } catch (error) {
+      toast.error("Could not save reminder preferences. Continuing.");
+    }
+  };
+
+  const handleSkipPartialPrompt = async () => {
+    const reminders = pendingSkippedDocs.map((documentName) => ({
+      document_name: documentName,
+      reason: "skipped",
+      expiry_date: null,
+      custom_reason: null,
+    }));
+    await persistGuestDeferred(reminders);
+    setShowPartialPrompt(false);
+    setStep(3);
+  };
+
+  const handleConfirmPartialPrompt = async (reminders) => {
+    await persistGuestDeferred(reminders);
+    setShowPartialPrompt(false);
     setStep(3);
   };
 
@@ -265,6 +308,12 @@ export default function RenewModal({ isOpen, onClose, initialPlateNumber }) {
       className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
       onClick={onClose}
     >
+      <PartialRenewalPromptModal
+        isOpen={showPartialPrompt}
+        skippedDocs={pendingSkippedDocs}
+        onSkip={handleSkipPartialPrompt}
+        onConfirm={handleConfirmPartialPrompt}
+      />
       <div
         className="relative flex w-full max-w-4xl overflow-hidden rounded-2xl bg-white shadow-xl flex-col md:flex-row max-h-[90vh] md:h-auto text-left overflow-y-auto"
         onClick={(e) => e.stopPropagation()}

--- a/src/components/shared/PartialRenewalPromptModal.jsx
+++ b/src/components/shared/PartialRenewalPromptModal.jsx
@@ -1,0 +1,153 @@
+import React, { useMemo, useState } from "react";
+
+export default function PartialRenewalPromptModal({
+  isOpen,
+  skippedDocs = [],
+  onConfirm,
+  onSkip,
+}) {
+  const [answers, setAnswers] = useState({});
+
+  const docs = useMemo(
+    () => (Array.isArray(skippedDocs) ? skippedDocs.filter(Boolean) : []),
+    [skippedDocs],
+  );
+
+  if (!isOpen) return null;
+
+  const setReason = (doc, reason) => {
+    setAnswers((prev) => ({
+      ...prev,
+      [doc]: {
+        ...(prev[doc] || {}),
+        reason,
+      },
+    }));
+  };
+
+  const setField = (doc, key, value) => {
+    setAnswers((prev) => ({
+      ...prev,
+      [doc]: {
+        ...(prev[doc] || {}),
+        [key]: value,
+      },
+    }));
+  };
+
+  const buildPayload = () =>
+    docs.map((doc) => {
+      const answer = answers[doc] || {};
+      const reason = answer.reason || "skipped";
+      return {
+        document_name: doc,
+        reason,
+        expiry_date: answer.expiry_date || null,
+        custom_reason: reason === "custom" ? answer.custom_reason || null : null,
+      };
+    });
+
+  return (
+    <div
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/75 backdrop-blur-md p-4"
+      onClick={(e) => {
+        e.stopPropagation();
+        onSkip();
+      }}
+    >
+      <div
+        className="w-full max-w-3xl rounded-2xl bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-xl font-semibold text-[#05243F]">You've skipped some documents</h3>
+        <p className="mt-1 text-sm text-[#697C8C]">
+          Tell us why, or skip and pay now. We can remind you later.
+        </p>
+
+        <div className="mt-5 max-h-[52vh] space-y-4 overflow-y-auto pr-1">
+          {docs.map((doc) => {
+            const row = answers[doc] || {};
+            const reason = row.reason || "";
+            return (
+              <div key={doc} className="rounded-xl border border-[#E5E7EB] p-4">
+                <div className="text-sm font-semibold text-[#05243F]">{doc}</div>
+
+                <div className="mt-3 flex flex-wrap gap-3 text-sm">
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name={`reason-${doc}`}
+                      checked={reason === "not_expired"}
+                      onChange={() => setReason(doc, "not_expired")}
+                    />
+                    Not expired yet
+                  </label>
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name={`reason-${doc}`}
+                      checked={reason === "already_handled"}
+                      onChange={() => setReason(doc, "already_handled")}
+                    />
+                    Already handled
+                  </label>
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name={`reason-${doc}`}
+                      checked={reason === "custom"}
+                      onChange={() => setReason(doc, "custom")}
+                    />
+                    Other reason
+                  </label>
+                </div>
+
+                {(reason === "not_expired" || reason === "custom") && (
+                  <div className="mt-3">
+                    <label className="mb-1 block text-xs text-[#697C8C]">Expiry date (optional)</label>
+                    <input
+                      type="date"
+                      value={row.expiry_date || ""}
+                      onChange={(e) => setField(doc, "expiry_date", e.target.value)}
+                      className="w-full rounded-lg border border-[#D1D5DB] px-3 py-2 text-sm outline-none focus:border-[#2389E3]"
+                    />
+                  </div>
+                )}
+
+                {reason === "custom" && (
+                  <div className="mt-3">
+                    <label className="mb-1 block text-xs text-[#697C8C]">Custom reason</label>
+                    <input
+                      type="text"
+                      value={row.custom_reason || ""}
+                      onChange={(e) => setField(doc, "custom_reason", e.target.value)}
+                      placeholder="Tell us why you skipped this one"
+                      className="w-full rounded-lg border border-[#D1D5DB] px-3 py-2 text-sm outline-none focus:border-[#2389E3]"
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="rounded-full border border-[#D1D5DB] px-5 py-2 text-sm font-medium text-[#05243F] hover:bg-[#F9FAFB]"
+          >
+            Skip &amp; Pay
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(buildPayload())}
+            className="rounded-full bg-[#2284DB] px-5 py-2 text-sm font-semibold text-white hover:bg-[#1B6CB3]"
+          >
+            Confirm &amp; Pay
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/licenses/RenewLicense.jsx
+++ b/src/features/licenses/RenewLicense.jsx
@@ -10,6 +10,8 @@ import { FaArrowLeft, FaCarAlt } from "react-icons/fa";
 import { formatCurrency } from "../../utils/formatCurrency";
 import CarDetailsCard from "../../components/CarDetailsCard";
 import SearchableSelect from "../../components/shared/SearchableSelect";
+import PartialRenewalPromptModal from "../../components/shared/PartialRenewalPromptModal";
+import { saveDeferredReminders } from "../../services/apiDeferredReminders";
 import { ClipLoader } from "react-spinners";
 import toast from "react-hot-toast";
 import { Icon } from "@iconify/react";
@@ -71,6 +73,9 @@ export default function RenewLicense() {
   const [inlinePhone, setInlinePhone] = useState("");
   const [isSavingPhone, setIsSavingPhone] = useState(false);
   const [phoneStep, setPhoneStep] = useState(""); // "saving" | "initializing"
+  const [showPartialPrompt, setShowPartialPrompt] = useState(false);
+  const [pendingPaymentPayload, setPendingPaymentPayload] = useState(null);
+  const [pendingSkippedDocs, setPendingSkippedDocs] = useState([]);
 
   const isState = state?.data;
 
@@ -368,9 +373,55 @@ export default function RenewLicense() {
       } : {}),
     };
 
+    const unpaidDocs = docOptions.filter(
+      (doc) => !existingPayments.some((p) => p.payment_head_name === doc),
+    );
+    const skippedDocs = unpaidDocs.filter((doc) => !selectedDocs.includes(doc));
+
+    if (skippedDocs.length > 0) {
+      setPendingPaymentPayload(paymentPayload);
+      setPendingSkippedDocs(skippedDocs);
+      setShowPartialPrompt(true);
+      return;
+    }
+
     // Initialize payment for all selected schedules
     if (paymentPayload.payment_schedule_id.length > 0) {
       startPayment(paymentPayload);
+    }
+  };
+
+  const persistDeferred = async (reminders) => {
+    if (!carDetail?.slug || !Array.isArray(reminders) || reminders.length === 0) return;
+    try {
+      await saveDeferredReminders({
+        car_slug: carDetail.slug,
+        reminders,
+      });
+    } catch (error) {
+      toast.error("Could not save reminder preferences. Continuing to payment.");
+    }
+  };
+
+  const handleSkipPartialPrompt = async () => {
+    const reminders = pendingSkippedDocs.map((documentName) => ({
+      document_name: documentName,
+      reason: "skipped",
+      expiry_date: null,
+      custom_reason: null,
+    }));
+    await persistDeferred(reminders);
+    setShowPartialPrompt(false);
+    if (pendingPaymentPayload?.payment_schedule_id?.length > 0) {
+      startPayment(pendingPaymentPayload);
+    }
+  };
+
+  const handleConfirmPartialPrompt = async (reminders) => {
+    await persistDeferred(reminders);
+    setShowPartialPrompt(false);
+    if (pendingPaymentPayload?.payment_schedule_id?.length > 0) {
+      startPayment(pendingPaymentPayload);
     }
   };
 
@@ -922,6 +973,12 @@ export default function RenewLicense() {
           </div>
         </div>
       </div>
+      <PartialRenewalPromptModal
+        isOpen={showPartialPrompt}
+        skippedDocs={pendingSkippedDocs}
+        onSkip={handleSkipPartialPrompt}
+        onConfirm={handleConfirmPartialPrompt}
+      />
     </>
   );
 }

--- a/src/services/apiDeferredReminders.js
+++ b/src/services/apiDeferredReminders.js
@@ -1,0 +1,17 @@
+import { api } from "./apiClient";
+import axios from "axios";
+import config from "../config/config";
+
+const guestApi = axios.create({
+  baseURL: config.getApiBaseUrl(),
+});
+
+export async function saveDeferredReminders(payload) {
+  const { data } = await api.post("/renewals/deferred-reminders", payload);
+  return data;
+}
+
+export async function saveGuestDeferredReminders(payload) {
+  const { data } = await guestApi.post("/guest/renewals/deferred-reminders", payload);
+  return data;
+}


### PR DESCRIPTION
Prompt users when they skip document renewals, allow optional reasons, and save deferred reminder preferences before continuing payment in guest and authenticated flows.

