### PR TITLE
feat(ladipo): vehicle compatibility filtering and fitment badges

### DIFF
--- a/src/features/ladipo/Ladipo.jsx
+++ b/src/features/ladipo/Ladipo.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Icon } from "@iconify/react";
 import { X } from "lucide-react";
@@ -17,6 +17,7 @@ export default function Ladipo() {
   const [searchTerm, setSearchTerm] = useState("");
   const [activeSearch, setActiveSearch] = useState("");
   const [selectedCar, setSelectedCar] = useState(null);
+  const hasAutoSelectedSingleCar = useRef(false);
   const [subcategories, setSubcategories] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 12; // 3 rows on desktop (4 columns), 6 items on mobile (2 columns)
@@ -33,6 +34,13 @@ export default function Ladipo() {
     const carArray = cars?.cars || [];
     return Array.isArray(carArray) ? carArray : Object.values(carArray);
   }, [cars]);
+
+  useEffect(() => {
+    if (garageCars.length === 1 && !selectedCar && !hasAutoSelectedSingleCar.current) {
+      hasAutoSelectedSingleCar.current = true;
+      setSelectedCar(garageCars[0]);
+    }
+  }, [garageCars, selectedCar]);
 
   // Fetch subcategories when main category changes
   useEffect(() => {
@@ -53,29 +61,30 @@ export default function Ladipo() {
     fetchSubcategories();
   }, [selectedMainCategory]);
 
-  const effectiveSearch = useMemo(() => {
-    const terms = [];
-    if (activeSearch) terms.push(activeSearch);
-    if (selectedCar) {
-      terms.push(`${selectedCar.vehicle_make} ${selectedCar.vehicle_model}`);
-    }
-    return terms.join(" ") || undefined;
-  }, [activeSearch, selectedCar]);
-
   // Fetch parts based on category/subcategory
   const { data: partsData, isLoading: partsLoading } = useQuery({
     queryKey: [
       "ladipo-parts",
       selectedMainCategory?.slug,
       selectedSubcategory?.slug,
-      effectiveSearch,
+      activeSearch,
+      selectedCar?.vehicle_make,
+      selectedCar?.vehicle_model,
+      selectedCar?.vehicle_year,
       currentPage,
     ],
     queryFn: async () => {
+      const carParams = {
+        make: selectedCar?.vehicle_make || undefined,
+        model: selectedCar?.vehicle_model || undefined,
+        year: selectedCar?.vehicle_year || undefined,
+      };
+
       // If no category selected, get all parts
       if (!selectedMainCategory) {
         const result = await getLadipoParts({
-          q: effectiveSearch,
+          q: activeSearch || undefined,
+          ...carParams,
           limit: itemsPerPage,
           page: currentPage,
         });
@@ -92,13 +101,27 @@ export default function Ladipo() {
         const result = await getLadipoPartsByCategory(
           selectedMainCategory.slug,
           selectedSubcategory.slug,
-          { page: currentPage, limit: itemsPerPage }
+          {
+            page: currentPage,
+            limit: itemsPerPage,
+            q: activeSearch || undefined,
+            ...carParams,
+          }
         );
         return result;
       }
 
       // If only main category selected
-      const result = await getLadipoPartsByCategory(selectedMainCategory.slug, null, { page: currentPage, limit: itemsPerPage });
+      const result = await getLadipoPartsByCategory(
+        selectedMainCategory.slug,
+        null,
+        {
+          page: currentPage,
+          limit: itemsPerPage,
+          q: activeSearch || undefined,
+          ...carParams,
+        }
+      );
       return result;
     },
     staleTime: 60 * 1000,
@@ -352,7 +375,7 @@ export default function Ladipo() {
             </div>
           ) : (
             <>
-              <ProductsList parts={parts} />
+              <ProductsList parts={parts} selectedCar={selectedCar} garageCars={garageCars} />
               
               {/* Pagination */}
               {totalPages > 1 && (

--- a/src/features/ladipo/components/modal.jsx
+++ b/src/features/ladipo/components/modal.jsx
@@ -32,6 +32,12 @@ function ProductModal() {
     () => DOMPurify.sanitize(part?.description || ""),
     [part?.description]
   );
+  const publicSpecifications = useMemo(() => {
+    if (!part?.specifications || typeof part.specifications !== "object") return [];
+
+    const hiddenSpecKeys = new Set(["source", "source_url", "vendor", "supplier"]);
+    return Object.entries(part.specifications).filter(([key]) => !hiddenSpecKeys.has(String(key).toLowerCase()));
+  }, [part?.specifications]);
 
   function buildCartItem(quantityToUse) {
     return {
@@ -212,11 +218,11 @@ function ProductModal() {
             {/* Right Side - Details */}
             <div className="flex flex-col gap-6 lg:pl-6 lg:border-l lg:border-[#E1E6F4]">
               {/* Product Specification */}
-              {part.specifications && typeof part.specifications === "object" && Object.keys(part.specifications).length > 0 && (
+              {publicSpecifications.length > 0 && (
                 <div className="pb-6 border-b border-[#E1E6F4]">
                   <h4 className="text-[13px] font-bold text-[#05243F] mb-3 uppercase tracking-wide">Product Specification:</h4>
                   <div className="space-y-2">
-                    {Object.entries(part.specifications).slice(0, 3).map(([key, value]) => (
+                    {publicSpecifications.slice(0, 3).map(([key, value]) => (
                       <div key={key} className="text-[12px]">
                         <span className="text-[#697C8C]">{key.replace(/_/g, " ")}: </span>
                         <span className="text-[#05243F] font-semibold">{value}</span>

--- a/src/features/ladipo/components/productCard.jsx
+++ b/src/features/ladipo/components/productCard.jsx
@@ -9,7 +9,34 @@ const CONDITION_LABELS = {
   nigerian_used: { text: "Used", icon: "solar:refresh-bold", color: "bg-[#EBB850] text-white", borderColor: "border-[#EBB850]/40" },
 };
 
-function ProductCard({ part }) {
+function normalize(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function isCompatibilityMatch(car, rule) {
+  if (!car || !rule) return false;
+  const carMake = normalize(car.vehicle_make);
+  const carModel = normalize(car.vehicle_model);
+  const carYearRaw = car.vehicle_year;
+  const carYear = carYearRaw === undefined || carYearRaw === null || carYearRaw === ""
+    ? null
+    : Number(carYearRaw);
+
+  const ruleMake = normalize(rule.make);
+  const ruleModel = normalize(rule.model);
+
+  if (!ruleMake || carMake !== ruleMake) return false;
+  if (ruleModel && carModel !== ruleModel) return false;
+
+  if (carYear != null && Number.isFinite(carYear)) {
+    if (rule.year_min != null && carYear < Number(rule.year_min)) return false;
+    if (rule.year_max != null && carYear > Number(rule.year_max)) return false;
+  }
+
+  return true;
+}
+
+function ProductCard({ part, isCarFilterActive = false, selectedCar = null, garageCars = [] }) {
   const addItem = useCartStore((s) => s.addItem);
   const navigate = useNavigate();
 
@@ -42,6 +69,30 @@ function ProductCard({ part }) {
   }
 
   const condition = CONDITION_LABELS[part.condition] || CONDITION_LABELS.new;
+  const showUniversalBadge = part?.is_universal === true;
+  const compatibilityRows = Array.isArray(part?.compatibility) ? part.compatibility : [];
+  const allGarageCars = Array.isArray(garageCars) ? garageCars : [];
+  const matchedGarageCars = allGarageCars.filter((car) =>
+    compatibilityRows.some((rule) => isCompatibilityMatch(car, rule))
+  );
+  const selectedCarMatches = selectedCar
+    ? compatibilityRows.some((rule) => isCompatibilityMatch(selectedCar, rule))
+    : false;
+
+  let fitBadgeText = null;
+  if (!showUniversalBadge) {
+    if (selectedCar && selectedCarMatches) {
+      fitBadgeText = "Fits your car";
+    } else if (!selectedCar && matchedGarageCars.length > 0) {
+      fitBadgeText = matchedGarageCars.length === 1
+        ? "Fits 1 of your cars"
+        : `Fits ${matchedGarageCars.length} of your cars`;
+    } else if (isCarFilterActive) {
+      fitBadgeText = "Fits your car";
+    }
+  }
+
+  const showFitsBadge = !showUniversalBadge && !!fitBadgeText;
 
   return (
     <div className="group relative flex h-full w-full cursor-pointer flex-col rounded-[16px] border border-[#E1E6F4] bg-white p-4 transition-all duration-300 hover:border-[#2389E3]">
@@ -70,6 +121,16 @@ function ProductCard({ part }) {
         )}
 
       </div>
+
+      {(showFitsBadge || showUniversalBadge) && (
+        <span
+          className={`absolute bottom-4 left-4 z-10 rounded-[4px] px-1.5 py-[2px] text-[9px] font-bold ${
+            showUniversalBadge ? "bg-slate-500 text-white" : "bg-emerald-500 text-white"
+          }`}
+        >
+          {showUniversalBadge ? "Universal" : fitBadgeText}
+        </span>
+      )}
 
       <div className="flex flex-1 flex-col">
         <p className="mb-1 min-h-[3.5rem] text-[14px] font-bold leading-snug text-[#05243F] line-clamp-2">

--- a/src/features/ladipo/components/productsList.jsx
+++ b/src/features/ladipo/components/productsList.jsx
@@ -1,12 +1,12 @@
 import { Link } from "react-router-dom";
 import ProductCard from "./productCard";
 
-function ProductsList({ parts = [] }) {
+function ProductsList({ parts = [], selectedCar = null, garageCars = [] }) {
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 sm:gap-3">
       {parts.map((part) => (
         <Link key={part.id} to={`/ladipo/${part.slug}`} className="flex">
-          <ProductCard part={part} />
+          <ProductCard part={part} isCarFilterActive={!!selectedCar} selectedCar={selectedCar} garageCars={garageCars} />
         </Link>
       ))}
     </div>

--- a/src/pages/admin/AdminLadipo.jsx
+++ b/src/pages/admin/AdminLadipo.jsx
@@ -3,11 +3,14 @@ import toast from 'react-hot-toast';
 import { Icon } from '@iconify/react';
 import {
   createAdminLadipoProduct,
+  deleteAdminCompatibilityEntry,
   deleteAdminLadipoProduct,
+  getAdminPartCompatibility,
   getAdminLadipoCapabilities,
   getAdminLadipoOrder,
   listAdminLadipoOrders,
   listAdminLadipoProducts,
+  setAdminPartCompatibility,
   updateAdminLadipoOrderAssignee,
   updateAdminLadipoOrderStatus,
   updateAdminLadipoOrderWorkflow,
@@ -48,7 +51,15 @@ const initialProductForm = {
   price_kobo: '',
   stock_qty: '',
   seller_label: 'Motoka',
+  is_universal: false,
   is_active: true,
+};
+
+const emptyCompatibilityEntry = {
+  make: '',
+  model: '',
+  year_min: '',
+  year_max: '',
 };
 
 function formatPrice(kobo) {
@@ -210,6 +221,9 @@ export default function AdminLadipo() {
   const [productImageObjectUrl, setProductImageObjectUrl] = useState(null);
   const [editingProductCoverUrl, setEditingProductCoverUrl] = useState(null);
   const [savingProduct, setSavingProduct] = useState(false);
+  const [compatibilityEntries, setCompatibilityEntries] = useState([]);
+  const [compatibilityDraft, setCompatibilityDraft] = useState(emptyCompatibilityEntry);
+  const [compatibilityLoading, setCompatibilityLoading] = useState(false);
   const productImageInputRef = useRef(null);
   const slugManuallyEdited = useRef(false);
   // 'add' | 'edit' | 'view'
@@ -791,6 +805,23 @@ export default function AdminLadipo() {
     setSelectedOrderLoading(false);
   };
 
+  const loadProductCompatibility = async (productId) => {
+    if (!productId) {
+      setCompatibilityEntries([]);
+      return;
+    }
+    setCompatibilityLoading(true);
+    try {
+      const res = await getAdminPartCompatibility(productId);
+      setCompatibilityEntries(res?.data || []);
+    } catch {
+      setCompatibilityEntries([]);
+      toast.error('Failed to load compatibility entries');
+    } finally {
+      setCompatibilityLoading(false);
+    }
+  };
+
   const resetProductForm = () => {
     setProductForm(initialProductForm);
     setEditingProductId(null);
@@ -798,11 +829,14 @@ export default function AdminLadipo() {
     setEditingProductCoverUrl(null);
     setViewingProduct(null);
     setProductPanelMode('add');
+    setCompatibilityEntries([]);
+    setCompatibilityDraft(emptyCompatibilityEntry);
+    setCompatibilityLoading(false);
     slugManuallyEdited.current = false;
     if (productImageInputRef.current) productImageInputRef.current.value = '';
   };
 
-  const startEditProduct = (product) => {
+  const startEditProduct = async (product) => {
     slugManuallyEdited.current = true;
     setEditingProductId(product.id);
     setEditingProductCoverUrl(resolveAdminProductImageUrl(product));
@@ -817,15 +851,65 @@ export default function AdminLadipo() {
       price_kobo: product.inventory?.price_kobo ?? '',
       stock_qty: product.inventory?.stock_qty ?? '',
       seller_label: product.inventory?.seller_label || 'Motoka',
+      is_universal: product.is_universal ?? false,
       is_active: product.is_active ?? true,
     });
+    setCompatibilityDraft(emptyCompatibilityEntry);
     setProductImageFile(null);
     if (productImageInputRef.current) productImageInputRef.current.value = '';
+    await loadProductCompatibility(product.id);
   };
 
   const clearPendingProductImage = () => {
     setProductImageFile(null);
     if (productImageInputRef.current) productImageInputRef.current.value = '';
+  };
+
+  const addCompatibilityEntry = () => {
+    const make = String(compatibilityDraft.make || '').trim();
+    if (!make) {
+      toast.error('Compatibility make is required');
+      return;
+    }
+
+    const yearMin = compatibilityDraft.year_min === '' ? null : Number(compatibilityDraft.year_min);
+    const yearMax = compatibilityDraft.year_max === '' ? null : Number(compatibilityDraft.year_max);
+
+    if ((yearMin != null && Number.isNaN(yearMin)) || (yearMax != null && Number.isNaN(yearMax))) {
+      toast.error('Compatibility years must be valid numbers');
+      return;
+    }
+    if (yearMin != null && yearMax != null && yearMin > yearMax) {
+      toast.error('Year min cannot be greater than year max');
+      return;
+    }
+
+    setCompatibilityEntries((prev) => [
+      ...prev,
+      {
+        id: `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        make,
+        model: String(compatibilityDraft.model || '').trim(),
+        year_min: yearMin,
+        year_max: yearMax,
+      },
+    ]);
+    setCompatibilityDraft(emptyCompatibilityEntry);
+  };
+
+  const removeCompatibilityEntry = async (entryId) => {
+    if (!entryId) return;
+    const isServerEntry = !String(entryId).startsWith('local-');
+
+    if (isServerEntry) {
+      try {
+        await deleteAdminCompatibilityEntry(entryId);
+      } catch {
+        // Keep local UX responsive even when delete endpoint fails; save will upsert final set.
+      }
+    }
+
+    setCompatibilityEntries((prev) => prev.filter((entry) => entry.id !== entryId));
   };
 
   const priceNairaPreview = useMemo(() => {
@@ -838,6 +922,16 @@ export default function AdminLadipo() {
     event.preventDefault();
     setSavingProduct(true);
     try {
+      const normalizedCompatibility = (compatibilityEntries || [])
+        .map((entry) => ({
+          ...entry,
+          make: String(entry?.make || '').trim(),
+          model: String(entry?.model || '').trim(),
+          year_min: entry?.year_min === '' || entry?.year_min == null ? null : Number(entry.year_min),
+          year_max: entry?.year_max === '' || entry?.year_max == null ? null : Number(entry.year_max),
+        }))
+        .filter((entry) => entry.make);
+
       const payload = new FormData();
       payload.append('name', productForm.name);
       payload.append('slug', productForm.slug);
@@ -849,6 +943,7 @@ export default function AdminLadipo() {
       payload.append('price_kobo', String(Number(productForm.price_kobo)));
       payload.append('stock_qty', String(Number(productForm.stock_qty)));
       payload.append('seller_label', productForm.seller_label || 'Motoka');
+      payload.append('is_universal', String(Boolean(productForm.is_universal)));
       payload.append('is_active', String(Boolean(productForm.is_active)));
       if (editingProductId) {
         const existing = products.find((item) => item.id === editingProductId);
@@ -861,10 +956,22 @@ export default function AdminLadipo() {
       }
 
       if (editingProductId) {
-        await updateAdminLadipoProduct(editingProductId, payload);
+        const res = await updateAdminLadipoProduct(editingProductId, payload);
+        const targetPartId = res?.data?.id || editingProductId;
+        await setAdminPartCompatibility(
+          targetPartId,
+          productForm.is_universal ? [] : normalizedCompatibility
+        );
         toast.success('Product updated');
       } else {
-        await createAdminLadipoProduct(payload);
+        const res = await createAdminLadipoProduct(payload);
+        const targetPartId = res?.data?.id;
+        if (targetPartId) {
+          await setAdminPartCompatibility(
+            targetPartId,
+            productForm.is_universal ? [] : normalizedCompatibility
+          );
+        }
         toast.success('Product created');
       }
       resetProductForm();
@@ -1833,6 +1940,85 @@ export default function AdminLadipo() {
                     className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-[#2284DB] focus:ring-2 focus:ring-[#2284DB]/20"
                   />
                 </div>
+
+                <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={productForm.is_universal}
+                    onChange={(e) => setProductForm((prev) => ({ ...prev, is_universal: e.target.checked }))}
+                    className="rounded border-gray-300 text-[#2284DB] focus:ring-[#2284DB]"
+                  />
+                  Universal part (shows for all cars)
+                </label>
+
+                {!productForm.is_universal && (
+                  <div className="rounded-xl border border-gray-200 bg-gray-50/60 p-3 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <label className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        Compatibility entries
+                      </label>
+                      {compatibilityLoading && <span className="text-[11px] text-gray-400">Loading…</span>}
+                    </div>
+
+                    {compatibilityEntries.length === 0 ? (
+                      <p className="text-[11px] text-gray-500">No compatibility rows yet. Add at least one make/model/year range.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {compatibilityEntries.map((entry) => (
+                          <div key={entry.id} className="grid grid-cols-12 gap-2 rounded-lg border border-gray-200 bg-white px-2 py-2 text-xs">
+                            <div className="col-span-3 font-medium text-gray-700">{entry.make || '—'}</div>
+                            <div className="col-span-3 text-gray-600">{entry.model || 'All models'}</div>
+                            <div className="col-span-2 text-gray-600">{entry.year_min ?? 'Any'}</div>
+                            <div className="col-span-2 text-gray-600">{entry.year_max ?? 'Any'}</div>
+                            <button
+                              type="button"
+                              onClick={() => removeCompatibilityEntry(entry.id)}
+                              className="col-span-2 rounded-md border border-rose-200 text-rose-600 hover:bg-rose-50"
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="grid grid-cols-12 gap-2">
+                      <input
+                        value={compatibilityDraft.make}
+                        onChange={(e) => setCompatibilityDraft((prev) => ({ ...prev, make: e.target.value }))}
+                        placeholder="Make"
+                        className="col-span-3 rounded-lg border border-gray-200 px-2 py-2 text-xs outline-none focus:border-[#2284DB]"
+                      />
+                      <input
+                        value={compatibilityDraft.model}
+                        onChange={(e) => setCompatibilityDraft((prev) => ({ ...prev, model: e.target.value }))}
+                        placeholder="Model (optional)"
+                        className="col-span-3 rounded-lg border border-gray-200 px-2 py-2 text-xs outline-none focus:border-[#2284DB]"
+                      />
+                      <input
+                        type="number"
+                        value={compatibilityDraft.year_min}
+                        onChange={(e) => setCompatibilityDraft((prev) => ({ ...prev, year_min: e.target.value }))}
+                        placeholder="Year min"
+                        className="col-span-2 rounded-lg border border-gray-200 px-2 py-2 text-xs outline-none focus:border-[#2284DB]"
+                      />
+                      <input
+                        type="number"
+                        value={compatibilityDraft.year_max}
+                        onChange={(e) => setCompatibilityDraft((prev) => ({ ...prev, year_max: e.target.value }))}
+                        placeholder="Year max"
+                        className="col-span-2 rounded-lg border border-gray-200 px-2 py-2 text-xs outline-none focus:border-[#2284DB]"
+                      />
+                      <button
+                        type="button"
+                        onClick={addCompatibilityEntry}
+                        className="col-span-2 rounded-lg bg-[#2284DB] px-2 py-2 text-xs font-semibold text-white hover:bg-[#1d74c3]"
+                      >
+                        Add
+                      </button>
+                    </div>
+                  </div>
+                )}
 
                 {/* Image upload */}
                 <div className="rounded-xl border border-gray-200 bg-gray-50/60 p-3">

--- a/src/services/apiAdminLadipo.js
+++ b/src/services/apiAdminLadipo.js
@@ -177,3 +177,27 @@ export async function deleteAdminLadipoProduct(productId) {
   });
   return parseJsonResponse(res);
 }
+
+export async function getAdminPartCompatibility(partId) {
+  const res = await fetch(`${config.getApiBaseUrl()}/ladipo/parts/${partId}/compatibility`, {
+    headers: getAdminHeaders(),
+  });
+  return parseJsonResponse(res);
+}
+
+export async function setAdminPartCompatibility(partId, entries = []) {
+  const res = await fetch(`${config.getApiBaseUrl()}/ladipo/parts/${partId}/compatibility`, {
+    method: 'POST',
+    headers: getAdminHeaders(),
+    body: JSON.stringify({ entries }),
+  });
+  return parseJsonResponse(res);
+}
+
+export async function deleteAdminCompatibilityEntry(entryId) {
+  const res = await fetch(`${config.getApiBaseUrl()}/ladipo/compatibility/${entryId}`, {
+    method: 'DELETE',
+    headers: getAdminHeaders(),
+  });
+  return parseJsonResponse(res);
+}

--- a/src/services/apiLadipo.js
+++ b/src/services/apiLadipo.js
@@ -9,6 +9,9 @@ export const getLadipoParts = (params = {}) =>
 export const getLadipoPartBySlug = (slug) =>
   api.get(`/ladipo/parts/${slug}`).then((r) => r.data.data);
 
+export const getPartCompatibility = (partId) =>
+  api.get(`/ladipo/parts/${partId}/compatibility`).then((r) => r.data.data);
+
 export const createLadipoOrder = (data) =>
   api.post('/ladipo/orders', data).then((r) => r.data.data);
 

--- a/src/services/apiLadipoCategories.js
+++ b/src/services/apiLadipoCategories.js
@@ -180,12 +180,20 @@ export const getLadipoSubcategoryBySlug = async (mainCategorySlug, subcategorySl
 /**
  * Get parts filtered by main category and/or subcategory
  */
-export const getLadipoPartsByCategory = async (mainCategorySlug, subcategorySlug = null, { page = 1, limit = 12 } = {}) => {
+export const getLadipoPartsByCategory = async (
+  mainCategorySlug,
+  subcategorySlug = null,
+  { page = 1, limit = 12, q, make, model, year } = {}
+) => {
   try {
     const result = await getLadipoParts({
       category_slug: subcategorySlug || mainCategorySlug,
       page,
       limit,
+      q,
+      make,
+      model,
+      year,
     });
 
     const total = result?.total || 0;


### PR DESCRIPTION
Add make/model/year filtering via ladipo_part_compatibility table, auto-select single garage car, Fits-your-car badges on product cards, is_universal flag for oils/accessories, admin UI for managing compatibility entries, synonym-aware search, and hide vendor/supplier specs from public modal.

Made-with: Cursor