### PR TITLE
feat(ladipo): polish checkout, admin pricing, and product UX flows

### DIFF
--- a/src/features/ladipo/Ladipo.jsx
+++ b/src/features/ladipo/Ladipo.jsx
@@ -26,7 +26,6 @@ export default function Ladipo() {
   const {
     selectedMainCategory,
     selectedSubcategory,
-    filters,
   } = ladipoStore();
 
   const { cars } = useGetCars();
@@ -62,7 +61,7 @@ export default function Ladipo() {
   }, [selectedMainCategory]);
 
   // Fetch parts based on category/subcategory
-  const { data: partsData, isLoading: partsLoading } = useQuery({
+  const { data: partsData, isLoading: partsLoading, isError: partsError } = useQuery({
     queryKey: [
       "ladipo-parts",
       selectedMainCategory?.slug,
@@ -323,6 +322,13 @@ export default function Ladipo() {
               {Array.from({ length: 8 }).map((_, i) => (
                 <ProductSkeleton key={i} />
               ))}
+            </div>
+          ) : partsError ? (
+            <div className="flex flex-col items-center justify-center py-20 gap-3 bg-white rounded-2xl border border-[#E1E6F4]">
+              <p className="text-[16px] font-semibold text-[#05243F]">Failed to load parts</p>
+              <p className="text-[13px] text-[#697C8C] text-center max-w-xs">
+                Please check your connection and try again.
+              </p>
             </div>
           ) : parts.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 gap-4 bg-white rounded-2xl">

--- a/src/features/ladipo/LadipoCheckout.jsx
+++ b/src/features/ladipo/LadipoCheckout.jsx
@@ -11,15 +11,9 @@ import LadipoLayout from "./components/LadipoLayout";
 
 const DELIVERY_OPTIONS = [
   {
-    label: "Pickup",
-    description: "Lagos Island warehouse",
-    value: "pickup",
-    icon: "solar:shop-bold-duotone",
-  },
-  {
-    label: "Lagos Delivery",
+    label: "World wide",
     description: "Fee is calculated by your delivery location",
-    value: "lagos",
+    value: "standard",
     icon: "solar:scooter-bold-duotone",
   },
 ];
@@ -29,7 +23,7 @@ export default function LadipoCheckout() {
   const items = useCartStore((s) => s.items);
   const subtotalKobo = useCartStore(selectTotalKobo);
 
-  const [deliveryOption, setDeliveryOption] = useState(DELIVERY_OPTIONS[0]);
+  const deliveryOption = DELIVERY_OPTIONS[0];
   const [form, setForm] = useState({
     contact_name: "",
     phone: "",
@@ -52,18 +46,23 @@ export default function LadipoCheckout() {
     }
   }, [items.length, navigate]);
 
-  if (items.length === 0) {
-    return null;
-  }
-
-  const isPickup = deliveryOption.value === "pickup";
   const isState = state?.data;
   const selectedState = useMemo(
     () => (Array.isArray(isState) ? isState.find((s) => s.code === form.state) : null),
     [isState, form.state],
   );
-  const deliveryFeeKobo = isPickup ? 0 : Number(selectedState?.delivery_fee || 0);
+  const deliveryFeeKobo = Number(selectedState?.delivery_fee || 0);
   const totalKobo = subtotalKobo + deliveryFeeKobo;
+  const isCheckoutReady =
+    form.contact_name.trim() &&
+    form.phone.trim() &&
+    form.address.trim() &&
+    form.state &&
+    form.lga;
+
+  if (items.length === 0) {
+    return null;
+  }
 
   function handleFormChange(e) {
     const { name, value } = e.target;
@@ -136,12 +135,11 @@ export default function LadipoCheckout() {
   async function handleProceedToPayment(e) {
     e.preventDefault();
 
-    const requiresAddress = deliveryOption.value !== "pickup";
     if (!form.contact_name.trim()) return toast.error("Please enter your name");
     if (!form.phone.trim()) return toast.error("Please enter your phone number");
-    if (requiresAddress && !form.address.trim()) return toast.error("Please enter a delivery address");
-    if (requiresAddress && !form.state) return toast.error("Please select a state");
-    if (requiresAddress && !form.lga) return toast.error("Please select a local government");
+    if (!form.address.trim()) return toast.error("Please enter a delivery address");
+    if (!form.state) return toast.error("Please select a state");
+    if (!form.lga) return toast.error("Please select a local government");
 
     setLoading(true);
     try {
@@ -156,7 +154,7 @@ export default function LadipoCheckout() {
           address: form.address,
           state: form.state,
           lga: form.lga,
-          method: deliveryOption.value === "pickup" ? "pickup" : "standard",
+          method: "standard",
         },
       };
 
@@ -258,7 +256,7 @@ export default function LadipoCheckout() {
               </div>
 
               {/* Delivery method */}
-              <div className={`py-6 ${deliveryOption.value !== "pickup" ? "border-b border-[#E1E6F4]" : ""}`}>
+              <div className="py-6 border-b border-[#E1E6F4]">
                 <h3 className="text-[15px] font-bold text-[#05243F] mb-4 flex items-center gap-2">
                   <Icon icon="solar:delivery-bold-duotone" width="19" className="text-[#2389E3]" />
                   Delivery Method
@@ -267,8 +265,7 @@ export default function LadipoCheckout() {
                   {DELIVERY_OPTIONS.map((opt) => (
                     <label
                       key={opt.value}
-                      onClick={() => setDeliveryOption(opt)}
-                      className={`flex items-center gap-3 p-3.5 rounded-[12px] border-2 cursor-pointer transition-all ${
+                      className={`flex items-center gap-3 p-3.5 rounded-[12px] border-2 transition-all ${
                         deliveryOption.value === opt.value
                           ? "border-[#2389E3] bg-[#2389E3]/5"
                           : "border-[#E1E6F4] hover:border-[#2389E3]/30"
@@ -286,8 +283,8 @@ export default function LadipoCheckout() {
                         <p className="text-[14px] font-semibold text-[#05243F]">{opt.label}</p>
                         <p className="text-[12px] text-[#697C8C]">{opt.description}</p>
                       </div>
-                      <span className={`text-[13px] font-bold flex-shrink-0 ${opt.value === "pickup" ? "text-emerald-600" : "text-[#05243F]"}`}>
-                        {opt.value === "pickup" ? "Free" : "Calculated"}
+                      <span className="text-[13px] font-bold flex-shrink-0 text-[#05243F]">
+                        Calculated
                       </span>
                     </label>
                   ))}
@@ -295,73 +292,71 @@ export default function LadipoCheckout() {
               </div>
 
               {/* Delivery address */}
-              {deliveryOption.value !== "pickup" && (
-                <div className="pt-6">
-                  <h3 className="text-[15px] font-bold text-[#05243F] mb-4 flex items-center gap-2">
-                    <Icon icon="solar:map-point-bold-duotone" width="19" className="text-[#2389E3]" />
-                    Delivery Address
-                  </h3>
-                  <div className="flex flex-col gap-4">
-                    <div>
-                      <div className="text-sm font-medium text-[#05243F]">
-                        Delivery Address <span className="text-red-500">*</span>
-                      </div>
-                      <input
-                        type="text"
-                        name="address"
-                        placeholder="Street address"
-                        value={form.address}
-                        onChange={handleFormChange}
-                        className="mt-3 w-full rounded-[10px] bg-[#F4F5FC] p-4 text-sm text-[#05243F] transition-colors outline-none placeholder:text-[#05243F]/40 hover:bg-[#FFF4DD]/50 focus:bg-[#FFF4DD]"
-                      />
+              <div className="pt-6">
+                <h3 className="text-[15px] font-bold text-[#05243F] mb-4 flex items-center gap-2">
+                  <Icon icon="solar:map-point-bold-duotone" width="19" className="text-[#2389E3]" />
+                  Delivery Address
+                </h3>
+                <div className="flex flex-col gap-4">
+                  <div>
+                    <div className="text-sm font-medium text-[#05243F]">
+                      Delivery Address <span className="text-red-500">*</span>
                     </div>
-                    <div className="grid grid-cols-2 gap-4">
-                      <SearchableSelect
-                        label={<>State <span className="text-red-500">*</span></>}
-                        name="state"
-                        value={form.stateName}
-                        onChange={handleStateChange}
-                        options={
-                          Array.isArray(isState)
-                            ? isState.map((entry) => ({ id: entry.id, name: entry.state_name }))
-                            : []
-                        }
-                        placeholder="Select state"
-                        filterKey="name"
-                        isLoading={isGettingState}
-                        allowCustom={true}
-                      />
-                      <SearchableSelect
-                        label={<>Local Government <span className="text-red-500">*</span></>}
-                        name="lga"
-                        value={form.lga}
-                        onChange={handleLgaChange}
-                        options={
-                          Array.isArray(lgaOptions)
-                            ? lgaOptions.map((entry) => ({ id: entry.id, name: entry.lga_name }))
-                            : []
-                        }
-                        placeholder="Select local government"
-                        filterKey="name"
-                        isLoading={isGettingLG}
-                        disabled={!form.state}
-                        allowCustom={true}
-                      />
+                    <input
+                      type="text"
+                      name="address"
+                      placeholder="Street address"
+                      value={form.address}
+                      onChange={handleFormChange}
+                      className="mt-3 w-full rounded-[10px] bg-[#F4F5FC] p-4 text-sm text-[#05243F] transition-colors outline-none placeholder:text-[#05243F]/40 hover:bg-[#FFF4DD]/50 focus:bg-[#FFF4DD]"
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <SearchableSelect
+                      label={<>State <span className="text-red-500">*</span></>}
+                      name="state"
+                      value={form.stateName}
+                      onChange={handleStateChange}
+                      options={
+                        Array.isArray(isState)
+                          ? isState.map((entry) => ({ id: entry.id, name: entry.state_name }))
+                          : []
+                      }
+                      placeholder="Select state"
+                      filterKey="name"
+                      isLoading={isGettingState}
+                      allowCustom={true}
+                    />
+                    <SearchableSelect
+                      label={<>Local Government <span className="text-red-500">*</span></>}
+                      name="lga"
+                      value={form.lga}
+                      onChange={handleLgaChange}
+                      options={
+                        Array.isArray(lgaOptions)
+                          ? lgaOptions.map((entry) => ({ id: entry.id, name: entry.lga_name }))
+                          : []
+                      }
+                      placeholder="Select local government"
+                      filterKey="name"
+                      isLoading={isGettingLG}
+                      disabled={!form.state}
+                      allowCustom={true}
+                    />
+                  </div>
+                  <div>
+                    <div className="text-sm font-medium text-[#05243F]">
+                      Delivery Fee <span className="text-red-500">*</span>
                     </div>
-                    <div>
-                      <div className="text-sm font-medium text-[#05243F]">
-                        Delivery Fee <span className="text-red-500">*</span>
-                      </div>
-                      <input
-                        readOnly
-                        type="text"
-                        value={form.state ? `₦${(deliveryFeeKobo / 100).toLocaleString()}` : "Select a state first"}
-                        className="mt-3 w-full rounded-[10px] bg-[#F4F5FC] p-4 text-sm text-[#05243F] outline-none"
-                      />
-                    </div>
+                    <input
+                      readOnly
+                      type="text"
+                      value={form.state ? `₦${(deliveryFeeKobo / 100).toLocaleString()}` : "Select a state first"}
+                      className="mt-3 w-full rounded-[10px] bg-[#F4F5FC] p-4 text-sm text-[#05243F] outline-none"
+                    />
                   </div>
                 </div>
-              )}
+              </div>
             </div>
 
             {/* Right column - Order summary */}
@@ -388,8 +383,8 @@ export default function LadipoCheckout() {
                   </div>
                   <div className="flex justify-between text-[13px]">
                     <span className="text-[#697C8C]">Delivery</span>
-                    <span className={`font-semibold ${isPickup ? "text-emerald-600" : "text-[#05243F]"}`}>
-                      {isPickup ? "Free" : (form.state ? `₦${(deliveryFeeKobo / 100).toLocaleString()}` : "Select state")}
+                    <span className="font-semibold text-[#05243F]">
+                      {form.state ? `₦${(deliveryFeeKobo / 100).toLocaleString()}` : "Select state"}
                     </span>
                   </div>
                   <div className="border-t border-[#E1E6F4] pt-2 mt-2 flex justify-between items-baseline">
@@ -400,7 +395,7 @@ export default function LadipoCheckout() {
 
                 <button
                   type="submit"
-                  disabled={loading}
+                  disabled={loading || !isCheckoutReady}
                   className="w-full mt-4 bg-[#2389E3] py-3.5 rounded-[12px] text-white font-semibold text-[15px] hover:bg-[#1a7acf] transition-all active:scale-[0.98] flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
                 >
                   {loading ? (

--- a/src/features/ladipo/components/Categories.jsx
+++ b/src/features/ladipo/components/Categories.jsx
@@ -12,6 +12,7 @@ function Categories() {
 
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const scrollContainerRef = useRef(null);
@@ -21,10 +22,11 @@ function Categories() {
     const fetchCategories = async () => {
       try {
         setLoading(true);
+        setError("");
         const data = await getLadipoMainCategories();
         setCategories(data);
-      } catch (error) {
-        console.error("Error fetching categories:", error);
+      } catch {
+        setError("Unable to load categories right now.");
       } finally {
         setLoading(false);
       }
@@ -71,6 +73,14 @@ function Categories() {
             <div className="h-3 w-12 bg-[#F4F5FC] animate-pulse rounded" />
           </div>
         ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="w-full rounded-xl border border-[#F2D3D3] bg-[#FFF7F7] px-4 py-3 text-[13px] text-[#A33A3A]">
+        {error}
       </div>
     );
   }

--- a/src/features/ladipo/components/modal.jsx
+++ b/src/features/ladipo/components/modal.jsx
@@ -18,7 +18,6 @@ function ProductModal() {
   const navigate = useNavigate();
   const { slug } = useParams();
   const [selectedImage, setSelectedImage] = useState(0);
-  const [qty, setQty] = useState(1);
   const [touchStart, setTouchStart] = useState(null);
 
   const addItem = useCartStore((s) => s.addItem);
@@ -153,7 +152,7 @@ function ProductModal() {
     : [part.primary_image_url].filter(Boolean);
 
   const keyFeatures = Array.isArray(part.key_features) ? part.key_features : [];
-  const displayQty = Math.max(1, qty);
+  const displayQty = 1;
   return (
     <LadipoLayout
       title={part.name}
@@ -191,15 +190,13 @@ function ProductModal() {
 
               {/* Thumbnails */}
               <div className="mt-5 flex justify-between">
-                {[...Array(4)].map((_, i) => {
-                  // If we don't have enough unique images, just repeat the available ones
-                  const imgToShow = images[i % images.length];
+                {images.map((imgToShow, i) => {
                   return (
                     <button
                       key={i}
-                      onClick={() => setSelectedImage(i % images.length)}
+                      onClick={() => setSelectedImage(i)}
                       className={`flex-shrink-0 h-[70px] sm:h-[80px] w-[70px] sm:w-[80px] rounded-[16px] border overflow-hidden p-2 transition-all cursor-pointer ${
-                        selectedImage === (i % images.length) && i < images.length
+                        selectedImage === i
                           ? "border-[#2389E3] ring-1 ring-[#2389E3] bg-[#2389E3]/5"
                           : "border-[#E1E6F4] bg-[#F4F5FC] hover:border-[#2389E3]/50"
                       }`}

--- a/src/features/ladipo/components/productCard.jsx
+++ b/src/features/ladipo/components/productCard.jsx
@@ -68,6 +68,11 @@ function ProductCard({ part, isCarFilterActive = false, selectedCar = null, gara
     navigate("/ladipo/cart-page");
   }
 
+  function handleCardOpen() {
+    if (!part?.slug) return;
+    navigate(`/ladipo/${part.slug}`);
+  }
+
   const condition = CONDITION_LABELS[part.condition] || CONDITION_LABELS.new;
   const showUniversalBadge = part?.is_universal === true;
   const compatibilityRows = Array.isArray(part?.compatibility) ? part.compatibility : [];
@@ -95,7 +100,19 @@ function ProductCard({ part, isCarFilterActive = false, selectedCar = null, gara
   const showFitsBadge = !showUniversalBadge && !!fitBadgeText;
 
   return (
-    <div className="group relative flex h-full w-full cursor-pointer flex-col rounded-[16px] border border-[#E1E6F4] bg-white p-4 transition-all duration-300 hover:border-[#2389E3]">
+    <div
+      className="group relative flex h-full w-full cursor-pointer flex-col rounded-[16px] border border-[#E1E6F4] bg-white p-4 transition-all duration-300 hover:border-[#2389E3]"
+      onClick={handleCardOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleCardOpen();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${part?.name || "product"} details`}
+    >
       <button
         onClick={handleAddToCart}
         className="absolute top-4 right-4 z-10 flex h-6 w-6 items-center justify-center rounded-md bg-[#DFE4E8] text-white transition-colors group-hover:bg-[#2389E3]"

--- a/src/features/ladipo/components/productsList.jsx
+++ b/src/features/ladipo/components/productsList.jsx
@@ -1,13 +1,10 @@
-import { Link } from "react-router-dom";
 import ProductCard from "./productCard";
 
 function ProductsList({ parts = [], selectedCar = null, garageCars = [] }) {
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 sm:gap-3">
       {parts.map((part) => (
-        <Link key={part.id} to={`/ladipo/${part.slug}`} className="flex">
-          <ProductCard part={part} isCarFilterActive={!!selectedCar} selectedCar={selectedCar} garageCars={garageCars} />
-        </Link>
+        <ProductCard key={part.id} part={part} isCarFilterActive={!!selectedCar} selectedCar={selectedCar} garageCars={garageCars} />
       ))}
     </div>
   );

--- a/src/features/settings/components/ladipo-my-orders.jsx
+++ b/src/features/settings/components/ladipo-my-orders.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { ChevronLeft } from "lucide-react";
 import { ClipLoader } from "react-spinners";
+import { useNavigate } from "react-router-dom";
 import { getUserLadipoOrders } from "../../../services/apiLadipo";
 
 function formatDate(iso) {
@@ -78,7 +79,7 @@ function getStatusDescription(statusKey, order) {
       : "Your order is on the way to your delivery address.",
     delivered: "Order delivered successfully.",
     cancelled: "This order has been cancelled.",
-    payment_failed: "Payment was not successful. Start checkout again.",
+    payment_failed: "Payment was not successful. Retry payment to continue this order.",
   };
   return descriptions[statusKey] || "";
 }
@@ -101,9 +102,27 @@ const TIMELINE_STEPS = [
 ];
 
 export default function LadipoMyOrders({ onNavigate }) {
+  const navigate = useNavigate();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  const handleRetryPayment = (order) => {
+    if (!order?.order_number) return;
+    const paymentData = {
+      type: "ladipo",
+      order_number: order.order_number,
+      amount: order.total_kobo,
+      price: order.total_kobo,
+      orderData: order,
+    };
+    try {
+      sessionStorage.setItem("paymentData", JSON.stringify(paymentData));
+    } catch {
+      // ignore sessionStorage failures and continue with navigation state
+    }
+    navigate("/payment?type=ladipo", { state: { paymentData } });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -257,15 +276,13 @@ export default function LadipoMyOrders({ onNavigate }) {
                   </div>
                 </div>
                 <div className="mt-3 flex flex-wrap gap-2">
-                  {statusKey === "awaiting_payment" && (
+                  {(statusKey === "awaiting_payment" || statusKey === "payment_failed") && (
                     <button
                       type="button"
-                      onClick={() => {
-                        window.location.href = "/ladipo/cart-page";
-                      }}
+                      onClick={() => handleRetryPayment(order)}
                       className="rounded-full bg-[#2284DB] px-3 py-1.5 text-xs font-semibold text-white hover:bg-[#1A73C2]"
                     >
-                      Pay now
+                      {statusKey === "payment_failed" ? "Retry payment" : "Pay now"}
                     </button>
                   )}
                   {(statusKey === "out_for_delivery" || statusKey === "processing") && (

--- a/src/features/settings/components/ladipo-my-orders.jsx
+++ b/src/features/settings/components/ladipo-my-orders.jsx
@@ -44,7 +44,7 @@ function getUserFacingStatus(order) {
   if (paymentStatus !== "paid") return "awaiting_payment";
   if (orderStatus === "pending_payment") return "confirmed";
   if (orderStatus === "processing") return "processing";
-  if (orderStatus === "shipped") return "out_for_delivery";
+  if (orderStatus === "out_for_delivery") return "out_for_delivery";
   if (orderStatus === "delivered") return "delivered";
   return "confirmed";
 }

--- a/src/pages/admin/AdminLadipo.jsx
+++ b/src/pages/admin/AdminLadipo.jsx
@@ -48,7 +48,7 @@ const initialProductForm = {
   description: '',
   condition: 'new',
   part_type: 'aftermarket',
-  price_kobo: '',
+  price_naira: '',
   stock_qty: '',
   seller_label: 'Motoka',
   is_universal: false,
@@ -648,7 +648,7 @@ export default function AdminLadipo() {
             expectedAdminOpsVersion: ord?.admin_ops_version,
           });
           successCount += 1;
-        } catch (error) {
+        } catch {
           // Keep bulk flow moving even if some orders fail.
         }
       }
@@ -848,7 +848,10 @@ export default function AdminLadipo() {
       description: product.description || '',
       condition: product.condition || 'new',
       part_type: product.part_type || 'aftermarket',
-      price_kobo: product.inventory?.price_kobo ?? '',
+      price_naira:
+        product.inventory?.price_kobo != null
+          ? Number(product.inventory.price_kobo) / 100
+          : '',
       stock_qty: product.inventory?.stock_qty ?? '',
       seller_label: product.inventory?.seller_label || 'Motoka',
       is_universal: product.is_universal ?? false,
@@ -912,11 +915,11 @@ export default function AdminLadipo() {
     setCompatibilityEntries((prev) => prev.filter((entry) => entry.id !== entryId));
   };
 
-  const priceNairaPreview = useMemo(() => {
-    const raw = productForm.price_kobo;
+  const priceKoboPreview = useMemo(() => {
+    const raw = productForm.price_naira;
     if (raw === '' || raw === null || Number.isNaN(Number(raw))) return null;
-    return formatPrice(Number(raw));
-  }, [productForm.price_kobo]);
+    return Math.round(Number(raw) * 100).toLocaleString('en-NG');
+  }, [productForm.price_naira]);
 
   const handleSaveProduct = async (event) => {
     event.preventDefault();
@@ -940,7 +943,7 @@ export default function AdminLadipo() {
       payload.append('description', productForm.description || '');
       payload.append('condition', productForm.condition);
       payload.append('part_type', productForm.part_type);
-      payload.append('price_kobo', String(Number(productForm.price_kobo)));
+      payload.append('price_kobo', String(Math.round(Number(productForm.price_naira) * 100)));
       payload.append('stock_qty', String(Number(productForm.stock_qty)));
       payload.append('seller_label', productForm.seller_label || 'Motoka');
       payload.append('is_universal', String(Boolean(productForm.is_universal)));
@@ -1900,20 +1903,20 @@ export default function AdminLadipo() {
 
                 <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-1.5">
-                    <label className="text-xs font-medium uppercase tracking-wide text-gray-500">Price (kobo)</label>
+                    <label className="text-xs font-medium uppercase tracking-wide text-gray-500">Price (naira)</label>
                     <input
                       type="number"
                       min="0"
-                      step="1"
-                      value={productForm.price_kobo}
-                      onChange={(e) => setProductForm((prev) => ({ ...prev, price_kobo: e.target.value }))}
-                      placeholder="e.g. 1500000"
+                      step="0.01"
+                      value={productForm.price_naira}
+                      onChange={(e) => setProductForm((prev) => ({ ...prev, price_naira: e.target.value }))}
+                      placeholder="e.g. 15000"
                       className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-[#2284DB] focus:ring-2 focus:ring-[#2284DB]/20"
                       required
                     />
-                    {priceNairaPreview && (
+                    {priceKoboPreview && (
                       <p className="text-[11px] text-gray-500">
-                        → <span className="font-semibold text-[#05243F]">{priceNairaPreview}</span>
+                        → <span className="font-semibold text-[#05243F]">{priceKoboPreview} kobo</span>
                       </p>
                     )}
                   </div>

--- a/src/services/apiLadipoCategories.js
+++ b/src/services/apiLadipoCategories.js
@@ -211,23 +211,11 @@ export const getLadipoPartsByCategory = async (
 };
 
 /**
- * Link a part to a subcategory
- */
-export const linkPartToSubcategory = async (_partId, _subcategoryId) => {
-  throw new Error("Linking parts to legacy Ladipo subcategories is no longer supported.");
-};
-
-/**
- * Unlink a part from a subcategory
- */
-export const unlinkPartFromSubcategory = async (_partId, _subcategoryId) => {
-  throw new Error("Unlinking parts from legacy Ladipo subcategories is no longer supported.");
-};
-
-/**
  * Get all subcategories for a part
  */
-export const getPartSubcategories = async (_partId) => {
-  const categories = await fetchCategories();
-  return categories.filter((category) => category.parent_id != null);
+export const getPartSubcategories = async (partId) => {
+  if (!partId) return [];
+  // No dedicated backend endpoint exists for part → subcategory mapping.
+  // Return an empty list so callers don't accidentally consume unrelated subcategories.
+  return [];
 };

--- a/src/store/cartStore.js
+++ b/src/store/cartStore.js
@@ -14,10 +14,11 @@ const useCartStore = create(
     (set, get) => ({
       items: [],
       initialized: false,
+      syncError: false,
 
       initializeCart: async () => {
         if (!authStorage.isAuthenticated()) {
-          set({ initialized: true });
+          set({ initialized: true, syncError: false });
           return;
         }
 
@@ -56,10 +57,10 @@ const useCartStore = create(
             })
             .filter(Boolean);
 
-          set({ items: mappedItems, initialized: true });
-        } catch (error) {
+          set({ items: mappedItems, initialized: true, syncError: false });
+        } catch {
           // Keep UI resilient: if backend sync fails, do not wipe local cart.
-          set({ initialized: true });
+          set({ initialized: true, syncError: true });
         }
       },
 


### PR DESCRIPTION
Fix order status mapping, remove invalid link-wrapped card actions, improve Ladipo browse error states, and simplify PDP thumbnails. Update checkout to default to worldwide delivery with required address fields and disable payment continuation until delivery inputs are complete; allow admin pricing input in naira while submitting kobo to the API.

Made-with: Cursor