### PR TITLE
fix(ladipo): map shipped orders to out-for-delivery timeline stage

### DIFF
--- a/src/features/settings/components/ladipo-my-orders.jsx
+++ b/src/features/settings/components/ladipo-my-orders.jsx
@@ -45,7 +45,7 @@ function getUserFacingStatus(order) {
   if (paymentStatus !== "paid") return "awaiting_payment";
   if (orderStatus === "pending_payment") return "confirmed";
   if (orderStatus === "processing") return "processing";
-  if (orderStatus === "out_for_delivery") return "out_for_delivery";
+  if (orderStatus === "out_for_delivery" || orderStatus === "shipped") return "out_for_delivery";
   if (orderStatus === "delivered") return "delivered";
   return "confirmed";
 }


### PR DESCRIPTION
Treat both shipped and out_for_delivery order status values as the same user-facing out-for-delivery step so order progress and status badge stay in sync with admin updates.

