### PR TITLE
feat(admin): canonical status enum + Payments rebuild; sidebar spacing

### DIFF
--- a/src/components/admin/AdminLayout.jsx
+++ b/src/components/admin/AdminLayout.jsx
@@ -159,11 +159,11 @@ const AdminLayout = () => {
   const Sidebar = () => (
     <aside className="flex h-full w-64 flex-col bg-[#05243F]">
       {/* Logo */}
-      <div className="flex items-center gap-2.5 px-5 py-5 border-b border-white/8">
-        <img src={Logo} alt="Motoka" className="h-7 w-auto" />
-        <div>
+      <div className="flex items-center gap-2 pl-3 pr-3 pt-8 pb-5 border-b border-white/8">
+        <img src={Logo} alt="Motoka" className="h-7 w-7 object-contain shrink-0" style={{height:28,width:28}} />
+        <div className="min-w-0">
           <p className="text-sm font-semibold text-white leading-tight">Motoka</p>
-          <span className="inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide bg-[#EBB950]/15 text-[#EBB950] leading-none">
+          <span className="inline-block mt-1 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide bg-[#EBB950]/15 text-[#EBB950] leading-none">
             ADMIN
           </span>
         </div>

--- a/src/features/ladipo/Ladipo.jsx
+++ b/src/features/ladipo/Ladipo.jsx
@@ -12,6 +12,8 @@ import SubcategoriesNav from "./components/SubcategoriesNav";
 import ProductsList from "./components/productsList";
 import ProductSkeleton from "./components/ProductSkeleton";
 import Searchbar from "./components/Searchbar";
+import AllCategoriesModal from "./components/AllCategoriesModal";
+import FilterSidebar from "./components/FilterSidebar";
 import ladipoStore from "../../store/ladipoStore";
 
 export default function Ladipo() {
@@ -23,6 +25,35 @@ export default function Ladipo() {
   const hasAutoSelectedSingleCar = useRef(false);
   const [subcategories, setSubcategories] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
+  const [showAllCategories, setShowAllCategories] = useState(false);
+  const [showMobileFilters, setShowMobileFilters] = useState(false);
+  const [sidebarFilters, setSidebarFilters] = useState({
+    brand: [],
+    condition: [],
+    part_type: [],
+    minPriceNgn: null,
+    maxPriceNgn: null,
+    sort: "newest",
+  });
+
+  const sidebarQueryParams = useMemo(() => {
+    const p = {};
+    if (sidebarFilters.brand?.length) p.brand = sidebarFilters.brand.join(",");
+    if (sidebarFilters.condition?.length) p.condition = sidebarFilters.condition.join(",");
+    if (sidebarFilters.part_type?.length) p.part_type = sidebarFilters.part_type.join(",");
+    if (sidebarFilters.minPriceNgn != null) p.min_price_kobo = sidebarFilters.minPriceNgn * 100;
+    if (sidebarFilters.maxPriceNgn != null) p.max_price_kobo = sidebarFilters.maxPriceNgn * 100;
+    if (sidebarFilters.sort && sidebarFilters.sort !== "newest") p.sort = sidebarFilters.sort;
+    return p;
+  }, [sidebarFilters]);
+
+  const hasSidebarFilters =
+    sidebarFilters.brand?.length > 0 ||
+    sidebarFilters.condition?.length > 0 ||
+    sidebarFilters.part_type?.length > 0 ||
+    sidebarFilters.minPriceNgn != null ||
+    sidebarFilters.maxPriceNgn != null ||
+    (sidebarFilters.sort && sidebarFilters.sort !== "newest");
   const itemsPerPage = 12; // 3 rows on desktop (4 columns), 6 items on mobile (2 columns)
 
   // Get store state and actions
@@ -74,6 +105,7 @@ export default function Ladipo() {
       selectedCar?.vehicle_model,
       selectedCar?.vehicle_year,
       currentPage,
+      sidebarQueryParams,
     ],
     queryFn: async () => {
       const carParams = {
@@ -87,6 +119,7 @@ export default function Ladipo() {
         const result = await getLadipoParts({
           q: activeSearch || undefined,
           ...carParams,
+          ...sidebarQueryParams,
           limit: itemsPerPage,
           page: currentPage,
         });
@@ -108,6 +141,7 @@ export default function Ladipo() {
             limit: itemsPerPage,
             q: activeSearch || undefined,
             ...carParams,
+            ...sidebarQueryParams,
           }
         );
         return result;
@@ -122,6 +156,7 @@ export default function Ladipo() {
           limit: itemsPerPage,
           q: activeSearch || undefined,
           ...carParams,
+          ...sidebarQueryParams,
         }
       );
       return result;
@@ -130,12 +165,13 @@ export default function Ladipo() {
   });
 
   const parts = partsData?.parts ?? [];
+  const totalParts = partsData?.total ?? parts.length;
   const totalPages = partsData?.totalPages ?? 1;
 
   // Reset to page 1 when filters change
   useEffect(() => {
     setCurrentPage(1);
-  }, [selectedMainCategory, selectedSubcategory, activeSearch, selectedCar]);
+  }, [selectedMainCategory, selectedSubcategory, activeSearch, selectedCar, sidebarQueryParams]);
 
   function handlePageChange(page) {
     setCurrentPage(page);
@@ -146,10 +182,22 @@ export default function Ladipo() {
     setActiveSearch(typeof overrideTerm === "string" ? overrideTerm : searchTerm);
   }
 
+  function resetSidebarFilters() {
+    setSidebarFilters({
+      brand: [],
+      condition: [],
+      part_type: [],
+      minPriceNgn: null,
+      maxPriceNgn: null,
+      sort: "newest",
+    });
+  }
+
   function clearAllFilters() {
     setSelectedCar(null);
     setActiveSearch("");
     setSearchTerm("");
+    resetSidebarFilters();
     ladipoStore.setState({
       selectedMainCategory: null,
       selectedMainCategoryId: null,
@@ -159,7 +207,7 @@ export default function Ladipo() {
   }
 
   const hasFilters =
-    selectedMainCategory || selectedSubcategory || selectedCar || activeSearch;
+    selectedMainCategory || selectedSubcategory || selectedCar || activeSearch || hasSidebarFilters;
 
   return (
     <LadipoLayout
@@ -189,7 +237,7 @@ export default function Ladipo() {
                 )}
               </p>
               <button
-                onClick={() => ladipoStore.getState().clearCategoryFilters()}
+                onClick={() => setShowAllCategories(true)}
                 className="text-[13px] font-semibold text-[#8B98A5] hover:text-[#05243F] transition-colors"
               >
                 See All
@@ -306,19 +354,50 @@ export default function Ladipo() {
           </>
         )}
 
-        {/* Results */}
-        <div className="border-t border-[#E1E6F4] pt-6 mt-6">
+        {/* Results + sidebar */}
+        <div className="border-t border-[#E1E6F4] pt-6 mt-6 flex flex-col lg:flex-row gap-6">
+          {/* Sidebar — desktop static, mobile drawer */}
+          <div className="hidden lg:block">
+            <FilterSidebar
+              filters={sidebarFilters}
+              onFiltersChange={(patch) => setSidebarFilters((f) => ({ ...f, ...patch }))}
+              categorySlug={selectedSubcategory?.slug || selectedMainCategory?.slug}
+              onClear={resetSidebarFilters}
+              hasActiveFilters={hasSidebarFilters}
+            />
+          </div>
+
+          {/* Mobile filter trigger */}
+          <div className="lg:hidden flex items-center justify-between">
+            <button
+              onClick={() => setShowMobileFilters(true)}
+              className="inline-flex items-center gap-2 rounded-lg border border-[#E1E6F4] bg-white px-3 py-2 text-[13px] font-semibold text-[#05243F]"
+            >
+              <Icon icon="solar:filter-bold-duotone" width="16" />
+              Filters
+              {hasSidebarFilters && (
+                <span className="ml-1 rounded-full bg-[#1A7ACF] px-2 py-0.5 text-[10px] text-white">
+                  on
+                </span>
+              )}
+            </button>
+            <p className="text-[12px] text-[#697C8C]">
+              {partsLoading ? "Searching..." : `${totalParts} ${totalParts === 1 ? "part" : "parts"}`}
+            </p>
+          </div>
+
+          <div className="flex-1 min-w-0">
           {hasFilters && (
-            <div className="flex items-center justify-between mb-3">
+            <div className="hidden lg:flex items-center justify-between mb-3">
               <p className="text-[13px] text-[#697C8C]">
                 {partsLoading ? (
                   "Searching..."
                 ) : (
                   <>
                     <span className="font-bold text-[#05243F] text-[15px]">
-                      {parts.length}
+                      {totalParts}
                     </span>{" "}
-                    {parts.length === 1 ? "part" : "parts"} found
+                    {totalParts === 1 ? "part" : "parts"} found
                   </>
                 )}
               </p>
@@ -486,9 +565,42 @@ export default function Ladipo() {
               )}
             </>
           )}
+          </div>
         </div>
         </div>
       </div>
+      <AllCategoriesModal
+        open={showAllCategories}
+        onClose={() => setShowAllCategories(false)}
+      />
+      {showMobileFilters && (
+        <div
+          className="fixed inset-0 z-50 flex items-end bg-black/40 lg:hidden"
+          onClick={() => setShowMobileFilters(false)}
+        >
+          <div
+            className="max-h-[85vh] w-full overflow-y-auto rounded-t-2xl bg-[#F9FAFC] p-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-[15px] font-bold text-[#05243F]">Filters</h3>
+              <button
+                onClick={() => setShowMobileFilters(false)}
+                className="text-[13px] font-semibold text-[#2389E3]"
+              >
+                Done
+              </button>
+            </div>
+            <FilterSidebar
+              filters={sidebarFilters}
+              onFiltersChange={(patch) => setSidebarFilters((f) => ({ ...f, ...patch }))}
+              categorySlug={selectedSubcategory?.slug || selectedMainCategory?.slug}
+              onClear={resetSidebarFilters}
+              hasActiveFilters={hasSidebarFilters}
+            />
+          </div>
+        </div>
+      )}
     </LadipoLayout>
   );
 }

--- a/src/features/ladipo/components/AllCategoriesModal.jsx
+++ b/src/features/ladipo/components/AllCategoriesModal.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { getAllLadipoCategoriesWithSubs } from "../../../services/apiLadipoCategories";
+import ladipoStore from "../../../store/ladipoStore";
+
+export default function AllCategoriesModal({ open, onClose }) {
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const { setSelectedMainCategory, setSelectedSubcategory } = ladipoStore();
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        setError("");
+        const data = await getAllLadipoCategoriesWithSubs();
+        if (!cancelled) setGroups(data || []);
+      } catch {
+        if (!cancelled) setError("Unable to load categories.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onEsc = (e) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onEsc);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onEsc);
+      document.body.style.overflow = "";
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handlePickMain = (category) => {
+    setSelectedMainCategory(category);
+    onClose();
+  };
+
+  const handlePickSub = (parent, sub) => {
+    setSelectedMainCategory(parent);
+    setSelectedSubcategory(sub);
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
+      onClick={onClose}
+    >
+      <div
+        className="relative flex h-full max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-[#E1E6F4] px-6 py-4">
+          <div>
+            <h2 className="text-[18px] font-bold text-[#05243F]">All categories</h2>
+            <p className="text-[12px] text-[#697C8C]">
+              Browse parts by category and subcategory.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 text-[#697C8C] hover:bg-[#F4F5FC]"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {loading ? (
+            <div className="space-y-6">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i}>
+                  <div className="mb-3 h-4 w-40 animate-pulse rounded bg-[#F4F5FC]" />
+                  <div className="flex flex-wrap gap-2">
+                    {Array.from({ length: 5 }).map((__, j) => (
+                      <div
+                        key={j}
+                        className="h-7 w-24 animate-pulse rounded-full bg-[#F4F5FC]"
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : error ? (
+            <p className="rounded-xl border border-[#F2D3D3] bg-[#FFF7F7] px-4 py-3 text-[13px] text-[#A33A3A]">
+              {error}
+            </p>
+          ) : groups.length === 0 ? (
+            <p className="text-[13px] text-[#697C8C]">No categories available.</p>
+          ) : (
+            <div className="space-y-6">
+              {groups.map((parent) => (
+                <section key={parent.id}>
+                  <button
+                    onClick={() => handlePickMain(parent)}
+                    className="mb-3 text-left text-[15px] font-bold text-[#05243F] hover:text-[#1A7ACF]"
+                  >
+                    {parent.name}
+                  </button>
+                  {parent.subcategories?.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {parent.subcategories.map((sub) => (
+                        <button
+                          key={sub.id}
+                          onClick={() => handlePickSub(parent, sub)}
+                          className="rounded-full border border-[#E1E6F4] px-3 py-1.5 text-[12px] font-semibold text-[#05243F] hover:border-[#1A7ACF] hover:bg-[#1A7ACF]/5 hover:text-[#1A7ACF]"
+                        >
+                          {sub.name}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-[12px] text-[#697C8C]">
+                      Tap to browse this category.
+                    </p>
+                  )}
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/ladipo/components/FilterSidebar.jsx
+++ b/src/features/ladipo/components/FilterSidebar.jsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { getLadipoPartFacets } from "../../../services/apiLadipo";
+
+const SORT_OPTIONS = [
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "name_asc", label: "Name (A–Z)" },
+];
+
+function CollapsibleSection({ title, defaultOpen = true, children }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-[#E1E6F4] py-4">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between text-[13px] font-bold text-[#05243F]"
+      >
+        <span>{title}</span>
+        {open ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+      </button>
+      {open && <div className="mt-3 space-y-2">{children}</div>}
+    </div>
+  );
+}
+
+function CheckboxRow({ label, count, checked, onChange }) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-2 text-[13px]">
+      <span className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={onChange}
+          className="h-4 w-4 cursor-pointer rounded border-[#D3D9DE] text-[#1A7ACF] focus:ring-[#1A7ACF]"
+        />
+        <span className={`${checked ? "font-semibold text-[#05243F]" : "text-[#465465]"}`}>
+          {label}
+        </span>
+      </span>
+      {count != null && (
+        <span className="text-[11px] text-[#8B98A5]">{count}</span>
+      )}
+    </label>
+  );
+}
+
+export default function FilterSidebar({
+  filters,
+  onFiltersChange,
+  categorySlug,
+  onClear,
+  hasActiveFilters,
+}) {
+  const { data: facets, isLoading } = useQuery({
+    queryKey: ["ladipo-facets", categorySlug || null],
+    queryFn: () => getLadipoPartFacets(categorySlug ? { category_slug: categorySlug } : {}),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const priceBounds = useMemo(() => {
+    const min = Math.floor((facets?.price_kobo?.min ?? 0) / 100);
+    const max = Math.ceil((facets?.price_kobo?.max ?? 0) / 100);
+    return { min, max };
+  }, [facets]);
+
+  const [localPrice, setLocalPrice] = useState({
+    min: filters.minPriceNgn ?? "",
+    max: filters.maxPriceNgn ?? "",
+  });
+
+  useEffect(() => {
+    setLocalPrice({
+      min: filters.minPriceNgn ?? "",
+      max: filters.maxPriceNgn ?? "",
+    });
+  }, [filters.minPriceNgn, filters.maxPriceNgn]);
+
+  const toggleArray = (key, value) => {
+    const current = filters[key] || [];
+    const next = current.includes(value)
+      ? current.filter((v) => v !== value)
+      : [...current, value];
+    onFiltersChange({ [key]: next });
+  };
+
+  const applyPrice = () => {
+    const min = localPrice.min === "" ? null : Math.max(0, parseInt(localPrice.min, 10) || 0);
+    const max = localPrice.max === "" ? null : Math.max(0, parseInt(localPrice.max, 10) || 0);
+    onFiltersChange({ minPriceNgn: min, maxPriceNgn: max });
+  };
+
+  return (
+    <aside className="w-full lg:w-64 lg:flex-shrink-0">
+      <div className="rounded-2xl border border-[#E1E6F4] bg-white px-5 py-4">
+        <div className="flex items-center justify-between border-b border-[#E1E6F4] pb-3">
+          <h3 className="text-[15px] font-bold text-[#05243F]">Filters</h3>
+          {hasActiveFilters && (
+            <button
+              onClick={onClear}
+              className="text-[12px] font-semibold text-[#2389E3] hover:text-[#1a7acf]"
+            >
+              Reset
+            </button>
+          )}
+        </div>
+
+        <CollapsibleSection title="Sort by">
+          <select
+            value={filters.sort || "newest"}
+            onChange={(e) => onFiltersChange({ sort: e.target.value })}
+            className="w-full rounded-lg border border-[#E1E6F4] bg-white px-3 py-2 text-[13px] text-[#05243F] focus:border-[#1A7ACF] focus:outline-none"
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Price (₦)">
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={priceBounds.min}
+              max={priceBounds.max}
+              placeholder={`Min ${priceBounds.min.toLocaleString()}`}
+              value={localPrice.min}
+              onChange={(e) => setLocalPrice((p) => ({ ...p, min: e.target.value }))}
+              onBlur={applyPrice}
+              onKeyDown={(e) => e.key === "Enter" && applyPrice()}
+              className="w-full rounded-lg border border-[#E1E6F4] bg-white px-2 py-1.5 text-[12px] text-[#05243F] focus:border-[#1A7ACF] focus:outline-none"
+            />
+            <span className="text-[12px] text-[#8B98A5]">–</span>
+            <input
+              type="number"
+              min={priceBounds.min}
+              max={priceBounds.max}
+              placeholder={`Max ${priceBounds.max.toLocaleString()}`}
+              value={localPrice.max}
+              onChange={(e) => setLocalPrice((p) => ({ ...p, max: e.target.value }))}
+              onBlur={applyPrice}
+              onKeyDown={(e) => e.key === "Enter" && applyPrice()}
+              className="w-full rounded-lg border border-[#E1E6F4] bg-white px-2 py-1.5 text-[12px] text-[#05243F] focus:border-[#1A7ACF] focus:outline-none"
+            />
+          </div>
+          {priceBounds.max > 0 && (
+            <p className="text-[11px] text-[#8B98A5]">
+              In catalog: ₦{priceBounds.min.toLocaleString()} – ₦{priceBounds.max.toLocaleString()}
+            </p>
+          )}
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Brand">
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-4 w-full animate-pulse rounded bg-[#F4F5FC]" />
+              ))}
+            </div>
+          ) : facets?.brands?.length ? (
+            <div className="max-h-56 space-y-2 overflow-y-auto pr-1">
+              {facets.brands.slice(0, 50).map((b) => (
+                <CheckboxRow
+                  key={b.value}
+                  label={b.value}
+                  count={b.count}
+                  checked={(filters.brand || []).includes(b.value)}
+                  onChange={() => toggleArray("brand", b.value)}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-[12px] text-[#8B98A5]">No brands available</p>
+          )}
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Condition">
+          {isLoading ? (
+            <div className="h-4 animate-pulse rounded bg-[#F4F5FC]" />
+          ) : facets?.conditions?.length ? (
+            facets.conditions.map((c) => (
+              <CheckboxRow
+                key={c.value}
+                label={c.value[0].toUpperCase() + c.value.slice(1)}
+                count={c.count}
+                checked={(filters.condition || []).includes(c.value)}
+                onChange={() => toggleArray("condition", c.value)}
+              />
+            ))
+          ) : (
+            <p className="text-[12px] text-[#8B98A5]">No conditions available</p>
+          )}
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Part type" defaultOpen={false}>
+          {isLoading ? (
+            <div className="h-4 animate-pulse rounded bg-[#F4F5FC]" />
+          ) : facets?.part_types?.length ? (
+            facets.part_types.map((p) => (
+              <CheckboxRow
+                key={p.value}
+                label={p.value[0].toUpperCase() + p.value.slice(1)}
+                count={p.count}
+                checked={(filters.part_type || []).includes(p.value)}
+                onChange={() => toggleArray("part_type", p.value)}
+              />
+            ))
+          ) : (
+            <p className="text-[12px] text-[#8B98A5]">No part types available</p>
+          )}
+        </CollapsibleSection>
+      </div>
+    </aside>
+  );
+}

--- a/src/features/payment/PaymentOptions.jsx
+++ b/src/features/payment/PaymentOptions.jsx
@@ -106,9 +106,20 @@ export default function PaymentOptions() {
         }
 
         setPaymentSession(sessionData);
-        // Default method selection: prefer provided method, else default to Monicredit
         const defaultMethod = sessionData.method || PAYMENT_METHODS.MONICREDIT;
         setSelectedMethod(defaultMethod);
+
+        // FIX 1: If Monicredit account details already exist (e.g. the user
+        // came from RenewLicense which already called /payments/initialize),
+        // skip re-initialization. Showing "Confirm Payment Method" here would
+        // create a second transaction and immediately abandon the first one.
+        const monicreditData = sessionData.monicredit?.data;
+        const alreadyInitialized =
+          monicreditData?.account_number ||
+          monicreditData?.customer?.account_number;
+        if (alreadyInitialized && defaultMethod === PAYMENT_METHODS.MONICREDIT) {
+          setIsPaymentMethodConfirmed(true);
+        }
       } catch (err) {
         console.error("Payment initialization error:", err);
         toast.error("Failed to initialize payment. Please try again.");
@@ -122,8 +133,18 @@ export default function PaymentOptions() {
   // Handle payment method selection
   const handleMethodSelect = (method) => {
     setSelectedMethod(method);
-    setIsPaymentMethodConfirmed(false);
     setMonicreditFallbackError(null);
+    // Auto-confirm Monicredit if account details already exist in the session
+    // (e.g. user switches back from Paystack after a prior Monicredit init)
+    const monicreditData = paymentSession?.monicredit?.data;
+    const alreadyInitialized =
+      monicreditData?.account_number ||
+      monicreditData?.customer?.account_number;
+    if (method === PAYMENT_METHODS.MONICREDIT && alreadyInitialized) {
+      setIsPaymentMethodConfirmed(true);
+    } else {
+      setIsPaymentMethodConfirmed(false);
+    }
   };
 
   // Helper function to build payment payload
@@ -460,7 +481,9 @@ export default function PaymentOptions() {
       }
 
       // Open Paystack in a new tab
-      const newWindow = window.open(paystackUrl, '_blank', 'noopener,noreferrer');
+      // FIX 2: Do not pass 'noopener' — the callback page needs window.opener
+      // to postMessage success back to this tab.
+      const newWindow = window.open(paystackUrl, '_blank');
       if (!newWindow) {
         toast.error('Please allow popups for this site to proceed with payment');
         return;
@@ -471,8 +494,11 @@ export default function PaymentOptions() {
       const checkPopup = setInterval(() => {
         if (newWindow.closed) {
           clearInterval(checkPopup);
-          // When the popup is closed, check payment status
-          checkPaystackStatus();
+          // FIX 4: Wait 3 seconds before polling — gives the callback page time
+          // to verify and send a PAYMENT_SUCCESS message first. Also covers the
+          // case where the user closes the tab a split-second before Paystack
+          // finishes its redirect.
+          setTimeout(checkPaystackStatus, 3000);
         }
       }, 1000);
     } catch (err) {
@@ -614,13 +640,16 @@ export default function PaymentOptions() {
           });
         }
       } else {
-        toast.error("Payment verification failed");
+        // FIX 3: Bank transfers can take a few minutes to clear. "failed" is
+        // misleading — tell the user to wait and try again instead.
+        toast.error("Transfer not yet confirmed. Please allow a few minutes and try again.");
         setIsProcessing(false);
       }
-    } catch {
+    } catch (err) {
       if (isLadipo) {
         useLadipoPaymentModalStore.getState().close();
       }
+      toast.error(err?.response?.data?.message || err?.message || "Verification failed. Please try again.");
       setIsProcessing(false);
     }
   };

--- a/src/features/payment/hooks/usePayment.js
+++ b/src/features/payment/hooks/usePayment.js
@@ -66,16 +66,12 @@ import { verifyPayment, verifyPaystackPayment } from '../../../services/apiPayme
 import { toast } from 'react-hot-toast';
 
 export function usePaymentVerification() {
+  // Toast handling is done by the caller (handleVerifyMonicredit in PaymentOptions)
+  // so we do not add onSuccess/onError here — that would cause duplicate toasts.
   const verifyMonicredit = useMutation({
     mutationFn: async (orderId) => {
       const response = await verifyPayment(orderId);
       return response;
-    },
-    onSuccess: (data) => {
-      toast.success(data?.message || 'Payment verified successfully!');
-    },
-    onError: (error) => {
-      toast.error(error.response.data.message ||error.message || 'Failed to verify payment');
     }
   });
 

--- a/src/pages/admin/AdminCarDetails.jsx
+++ b/src/pages/admin/AdminCarDetails.jsx
@@ -44,7 +44,7 @@ const StatusPill = ({ status }) => {
     expired:   { bg: 'bg-red-100 text-red-800',       label: 'Expired' },
     pending:   { bg: 'bg-blue-100 text-blue-800',     label: 'Pending' },
     completed: { bg: 'bg-green-100 text-green-800',   label: 'Completed' },
-    in_progress:{ bg: 'bg-orange-100 text-orange-800',label: 'In Progress' },
+    processing:{ bg: 'bg-orange-100 text-orange-800',label: 'In Progress' },
     cancelled: { bg: 'bg-gray-100 text-gray-600',     label: 'Cancelled' },
     successful:{ bg: 'bg-green-100 text-green-800',   label: 'Successful' },
     failed:    { bg: 'bg-red-100 text-red-800',       label: 'Failed' },
@@ -299,7 +299,7 @@ const AdminCarDetails = () => {
 
       {/* Hero Card */}
       <div className="overflow-hidden rounded-xl shadow">
-        <div className="bg-gradient-to-r from-blue-600 to-indigo-700 px-6 py-6">
+        <div className="bg-[#05243F] px-6 py-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-4">
               <div className="flex h-16 w-16 items-center justify-center rounded-xl bg-white/20 text-white">
@@ -313,7 +313,7 @@ const AdminCarDetails = () => {
                 <h2 className="text-2xl font-bold text-white">
                   {car.vehicle_make} {car.vehicle_model}
                 </h2>
-                <p className="text-blue-100 text-sm">
+                <p className="text-white/60 text-sm">
                   {car.vehicle_year} &bull; {car.vehicle_color} &bull; {car.car_type?.toUpperCase() || 'N/A'}
                 </p>
               </div>
@@ -343,7 +343,7 @@ const AdminCarDetails = () => {
           </div>
           <div className="bg-white px-4 py-3">
             <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Expiry Date</p>
-            <p className={`mt-1 text-lg font-bold ${isExpired ? 'text-red-600' : isUrgent ? 'text-yellow-600' : 'text-gray-900'}`}>
+            <p className={`mt-1 text-lg font-bold ${isExpired ? 'text-red-700' : isUrgent ? 'text-yellow-600' : 'text-gray-900'}`}>
               {formatDate(car.expiry_date)}
             </p>
           </div>

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -41,35 +41,39 @@ const AdminDashboard = () => {
   }, []);
 
   const fetchDashboardData = async () => {
-    try {
-      const token = localStorage.getItem('adminToken');
-      const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
+    const token = localStorage.getItem('adminToken');
+    const headers = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-      // All 4 fetches in parallel — stats, recent orders, transactions, full orders for chart
-      const [statsRes, ordersRes, txRes, allOrdersRes] = await Promise.all([
-        fetch(`${config.getApiBaseUrl()}/admin/dashboard/stats`, { headers }),
-        fetch(`${config.getApiBaseUrl()}/admin/recent-orders`, { headers }),
-        fetch(`${config.getApiBaseUrl()}/admin/recent-transactions`, { headers }),
-        fetch(`${config.getApiBaseUrl()}/admin/orders?page=1&per_page=200`, { headers }),
-      ]);
+    const safeJson = async (res) => {
+      try { return await res.json(); } catch { return null; }
+    };
 
-      const [statsData, ordersData, txData, allOrdersData] = await Promise.all([
-        statsRes.json(), ordersRes.json(), txRes.json(), allOrdersRes.json(),
-      ]);
+    const [statsResult, ordersResult, txResult, allOrdersResult] = await Promise.allSettled([
+      fetch(`${config.getApiBaseUrl()}/admin/dashboard/stats`, { headers }).then(safeJson),
+      fetch(`${config.getApiBaseUrl()}/admin/recent-orders`, { headers }).then(safeJson),
+      fetch(`${config.getApiBaseUrl()}/admin/recent-transactions`, { headers }).then(safeJson),
+      fetch(`${config.getApiBaseUrl()}/admin/orders?page=1&per_page=200`, { headers }).then(safeJson),
+    ]);
 
-      if (statsData.status) setStats(statsData.data);
-      if (ordersData.status) setRecentOrders(ordersData.data);
-      if (txData.status) setRecentTransactions(txData.data);
+    const statsData     = statsResult.status     === 'fulfilled' ? statsResult.value     : null;
+    const ordersData    = ordersResult.status     === 'fulfilled' ? ordersResult.value    : null;
+    const txData        = txResult.status         === 'fulfilled' ? txResult.value        : null;
+    const allOrdersData = allOrdersResult.status  === 'fulfilled' ? allOrdersResult.value : null;
 
-      const orders = allOrdersData.status
-        ? (allOrdersData.data?.data || allOrdersData.data || [])
-        : (ordersData.data || []);
-      setAllOrders(orders);
-    } catch (error) {
-      toast.error('Failed to fetch dashboard data');
-    } finally {
-      setLoading(false);
-    }
+    if (statsData?.status)  setStats(statsData.data);
+    if (ordersData?.status) setRecentOrders(ordersData.data);
+    if (txData?.status)     setRecentTransactions(txData.data);
+
+    const orders = allOrdersData?.status
+      ? (allOrdersData.data?.data || allOrdersData.data || [])
+      : (ordersData?.data || []);
+    setAllOrders(orders);
+
+    const allFailed = [statsResult, ordersResult, txResult, allOrdersResult]
+      .every(r => r.status === 'rejected' || !r.value);
+    if (allFailed) toast.error('Failed to fetch dashboard data');
+
+    setLoading(false);
   };
 
   const buildChartFromOrders = (orders, period) => {
@@ -107,17 +111,21 @@ const AdminDashboard = () => {
     if (built.length > 0) setChartData(built);
   }, [chartPeriod, allOrders, recentOrders]);
 
-  // Helper function to format order status
+  // Helper function to format order status. Accepts canonical DB values
+  // (pending|processing|completed|cancelled) and legacy aliases for
+  // transitional safety.
   const formatOrderStatus = (status) => {
     switch (status) {
       case 'pending':
         return 'New';
+      case 'processing':
       case 'in_progress':
         return 'In Progress';
       case 'completed':
         return 'Done';
+      case 'cancelled':
       case 'declined':
-        return 'Declined';
+        return 'Cancelled';
       default:
         return status;
     }

--- a/src/pages/admin/AdminOrderDetails.jsx
+++ b/src/pages/admin/AdminOrderDetails.jsx
@@ -239,10 +239,10 @@ const AdminOrderDetails = () => {
     }
 
     const statusConfig = {
-      pending: { color: 'bg-yellow-100 text-yellow-800', icon: ClockIcon },
-      in_progress: { color: 'bg-blue-100 text-blue-800', icon: ClockIcon },
-      completed: { color: 'bg-green-100 text-green-800', icon: CheckCircleIcon },
-      declined: { color: 'bg-red-100 text-red-800', icon: XCircleIcon },
+      pending:    { color: 'bg-yellow-100 text-yellow-800', icon: ClockIcon,        label: 'NEW' },
+      processing: { color: 'bg-blue-100 text-blue-800',     icon: ClockIcon,        label: 'IN PROGRESS' },
+      completed:  { color: 'bg-green-100 text-green-800',   icon: CheckCircleIcon,  label: 'COMPLETED' },
+      cancelled:  { color: 'bg-red-100 text-red-800',       icon: XCircleIcon,      label: 'CANCELLED' },
     };
 
     const config = statusConfig[status] || statusConfig.pending;
@@ -251,7 +251,7 @@ const AdminOrderDetails = () => {
     return (
       <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${config.color}`}>
         <Icon className="w-4 h-4 mr-2" />
-        {status.replace('_', ' ').toUpperCase()}
+        {config.label}
       </span>
     );
   };
@@ -512,14 +512,14 @@ const AdminOrderDetails = () => {
                     Mark this order as In Progress when you start processing it.
                   </p>
                   <button
-                    onClick={() => handleStatusUpdate('in_progress')}
+                    onClick={() => handleStatusUpdate('processing')}
                     disabled={statusUpdating}
                     className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 disabled:opacity-50 font-medium text-sm"
                   >
                     {statusUpdating ? 'Updating...' : 'Mark In Progress'}
                   </button>
                   <button
-                    onClick={() => handleStatusUpdate('declined')}
+                    onClick={() => handleStatusUpdate('cancelled')}
                     disabled={statusUpdating}
                     className="w-full border border-red-300 text-red-600 py-2 px-4 rounded-lg hover:bg-red-50 disabled:opacity-50 font-medium text-sm"
                   >
@@ -528,7 +528,7 @@ const AdminOrderDetails = () => {
                 </>
               )}
 
-              {order?.status === 'in_progress' && (
+              {order?.status === 'processing' && (
                 <>
                   {/* Inline document upload */}
                   <div className="border border-gray-200 rounded-lg overflow-hidden">
@@ -599,7 +599,7 @@ const AdminOrderDetails = () => {
                     {statusUpdating ? 'Updating...' : 'Mark as Completed'}
                   </button>
                   <button
-                    onClick={() => handleStatusUpdate('declined')}
+                    onClick={() => handleStatusUpdate('cancelled')}
                     disabled={statusUpdating}
                     className="w-full border border-red-300 text-red-600 py-2 px-4 rounded-lg hover:bg-red-50 disabled:opacity-50 font-medium text-sm"
                   >
@@ -608,11 +608,11 @@ const AdminOrderDetails = () => {
                 </>
               )}
 
-              {(order?.status === 'completed' || order?.status === 'declined') && (
+              {(order?.status === 'completed' || order?.status === 'cancelled') && (
                 <div className={`text-center py-3 rounded-lg text-sm font-medium ${
                   order.status === 'completed' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'
                 }`}>
-                  Order {order.status === 'completed' ? 'Completed' : 'Declined'}
+                  Order {order.status === 'completed' ? 'Completed' : 'Cancelled'}
                 </div>
               )}
             </div>

--- a/src/pages/admin/AdminOrders.jsx
+++ b/src/pages/admin/AdminOrders.jsx
@@ -9,10 +9,33 @@ import {
 import toast from 'react-hot-toast';
 import config from '../../config/config';
 
+// Canonical status values mirror the DB enum. Display labels (incl. "New"
+// for pending) live only here; the API never sees the labels and the UI
+// never sees the raw status without going through this map.
+const STATUS_FILTERS = [
+  { value: 'all',        label: 'All' },
+  { value: 'pending',    label: 'New' },
+  { value: 'processing', label: 'In Progress' },
+  { value: 'completed',  label: 'Completed' },
+  { value: 'cancelled',  label: 'Cancelled' },
+];
+const STATUS_LABEL = {
+  pending:    'New',
+  processing: 'In Progress',
+  completed:  'Completed',
+  cancelled:  'Cancelled',
+};
+const STATUS_COLOR = {
+  pending:    'text-blue-600',
+  processing: 'text-orange-600',
+  completed:  'text-green-600',
+  cancelled:  'text-red-600',
+};
+
 const AdminOrders = () => {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [activeFilter, setActiveFilter] = useState('All');
+  const [activeFilter, setActiveFilter] = useState('all');
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -33,17 +56,9 @@ const AdminOrders = () => {
     try {
       setLoading(true);
       const token = localStorage.getItem('adminToken');
-      
-      // Map display labels to backend status values
-      const filterStatusMap = {
-        'All': 'all',
-        'New': 'pending',
-        'In Progress': 'in_progress',
-        'Completed': 'completed',
-        'Declined': 'declined',
-      };
+
       const params = new URLSearchParams({
-        status: filterStatusMap[activeFilter] || 'all',
+        status: activeFilter,
         page: currentPage,
         per_page: perPage,
       });
@@ -93,7 +108,8 @@ const AdminOrders = () => {
     return type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()) || 'General Service';
   };
 
-  // Transform orders data to match Figma design
+  // Transform orders data for display. `status` stays canonical (DB shape);
+  // the table cell looks up STATUS_LABEL when rendering.
   const transformedOrders = orders.map(order => ({
     id: `#${order.slug?.substring(0, 8) || order.id}`,
     name: order.user?.name || 'Unknown User',
@@ -101,29 +117,9 @@ const AdminOrders = () => {
     amount: `N${parseFloat(order.amount || 0).toLocaleString()}`,
     location: order.state_name ? `${order.state_name}${order.lga_name ? ', ' + order.lga_name : ''}` : (order.order_type === 'plate_number' || order.order_type === 'driver_license' ? '—' : 'Unknown'),
     renewalState: order.renewal_state || null,
-    status: order.status === 'pending' ? 'New' :
-            order.status === 'in_progress' ? 'Inprogress' :
-            order.status === 'completed' ? 'Completed' :
-            order.status === 'declined' ? 'Declined' : 'New',
+    status: order.status,
     originalOrder: order
   }));
-
-  const filters = ['All', 'New', 'In Progress', 'Completed', 'Declined'];
-
-  const getStatusColor = (status) => {
-    switch (status) {
-      case 'New':
-        return 'text-blue-600';
-      case 'Completed':
-        return 'text-green-600';
-      case 'Inprogress':
-        return 'text-orange-600';
-      case 'Declined':
-        return 'text-red-600';
-      default:
-        return 'text-gray-600';
-    }
-  };
 
   const handleViewOrder = (order) => {
     window.location.href = `/admin/orders/${order.originalOrder.slug}`;
@@ -231,9 +227,9 @@ const AdminOrders = () => {
               onChange={(e) => handleFilterChange(e.target.value)}
               className="border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
             >
-              {filters.map((filter) => (
-                <option key={filter} value={filter}>
-                  {filter === 'All' ? 'All Orders' : filter}
+              {STATUS_FILTERS.map((f) => (
+                <option key={f.value} value={f.value}>
+                  {f.value === 'all' ? 'All Orders' : f.label}
                 </option>
               ))}
             </select>
@@ -243,17 +239,17 @@ const AdminOrders = () => {
 
       {/* Filter Tabs */}
       <div className="flex space-x-2 overflow-x-auto">
-        {filters.map((filter) => (
+        {STATUS_FILTERS.map((f) => (
           <button
-            key={filter}
-            onClick={() => handleFilterChange(filter)}
+            key={f.value}
+            onClick={() => handleFilterChange(f.value)}
             className={`px-4 py-2 rounded-full text-sm font-medium transition-colors whitespace-nowrap ${
-              activeFilter === filter
+              activeFilter === f.value
                 ? 'bg-blue-600 text-white'
                 : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
             }`}
           >
-            {filter}
+            {f.value === 'all' ? 'All' : f.label}
           </button>
         ))}
       </div>
@@ -327,8 +323,8 @@ const AdminOrders = () => {
                       ) : '—'}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">
-                      <span className={`text-sm font-medium ${getStatusColor(order.status)}`}>
-                        {order.status}
+                      <span className={`text-sm font-medium ${STATUS_COLOR[order.status] || 'text-gray-600'}`}>
+                        {STATUS_LABEL[order.status] || order.status}
                       </span>
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">

--- a/src/pages/admin/AdminPayments.jsx
+++ b/src/pages/admin/AdminPayments.jsx
@@ -14,17 +14,24 @@ import toast from 'react-hot-toast';
 import config from '../../config/config';
 import { markTransactionPaid, markTransactionFailed } from '../../services/apiAdminDocument';
 
+const EMPTY_SUMMARY = {
+  counts: { total: 0, successful: 0, pending: 0, failed: 0, abandoned: 0 },
+  amounts: { received: 0, received_kobo: 0, pending: 0, pending_kobo: 0 },
+  by_gateway: { paystack: 0, monicredit: 0 },
+};
+
+const GATEWAY_FILTERS = [
+  { value: 'all',        label: 'All Gateways' },
+  { value: 'monicredit', label: 'Monicredit' },
+  { value: 'paystack',   label: 'Paystack' },
+];
+
 const AdminPayments = () => {
   const [transactions, setTransactions] = useState([]);
-  const [summary, setSummary] = useState({
-    total_amount: 0,
-    total_transactions: 0,
-    successful_transactions: 0,
-    failed_transactions: 0,
-    pending_transactions: 0,
-  });
+  const [summary, setSummary] = useState(EMPTY_SUMMARY);
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState('All');
+  const [activeGateway, setActiveGateway] = useState('all');
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -47,17 +54,18 @@ const AdminPayments = () => {
       return;
     }
     fetchTransactions();
-  }, [activeFilter, currentPage, searchTerm]);
+  }, [activeFilter, activeGateway, currentPage, searchTerm]);
 
   const fetchTransactions = async () => {
     try {
       setLoading(true);
       const token = localStorage.getItem('adminToken');
-      
+
       const params = new URLSearchParams({
         page: currentPage,
         per_page: 15,
         status: activeFilter === 'All' ? 'all' : activeFilter.toLowerCase(),
+        gateway: activeGateway,
         search: searchTerm,
       });
 
@@ -194,15 +202,18 @@ const AdminPayments = () => {
         <h1 className="text-xl font-semibold text-gray-900">Transaction</h1>
       </div>
 
-      {/* Summary Cards */}
+      {/* Summary Cards — real "money received" view, broken out by state */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {/* Amount Entered */}
+        {/* Received */}
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-600">Amount Entered</p>
-              <p className="text-2xl font-bold text-blue-600">
-                {formatCurrency(summary.total_amount)}
+              <p className="text-sm font-medium text-gray-600">Received</p>
+              <p className="text-2xl font-bold text-green-600">
+                {formatCurrency(summary.amounts?.received ?? 0)}
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                {summary.counts?.successful ?? 0} successful
               </p>
             </div>
             <div className="h-8 w-8 bg-green-100 rounded-full flex items-center justify-center">
@@ -211,13 +222,34 @@ const AdminPayments = () => {
           </div>
         </div>
 
-        {/* Amount Spent */}
+        {/* Pending — money that should be coming in but hasn't settled */}
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-600">Amount Spent</p>
-              <p className="text-2xl font-bold text-blue-600">
-                {formatCurrency(summary.successful_transactions > 0 ? summary.total_amount : 0)}
+              <p className="text-sm font-medium text-gray-600">Pending</p>
+              <p className="text-2xl font-bold text-yellow-600">
+                {formatCurrency(summary.amounts?.pending ?? 0)}
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                {summary.counts?.pending ?? 0} awaiting payment
+              </p>
+            </div>
+            <div className="h-8 w-8 bg-yellow-100 rounded-full flex items-center justify-center">
+              <ArrowDownIcon className="h-5 w-5 text-yellow-600" />
+            </div>
+          </div>
+        </div>
+
+        {/* Failed / Abandoned (counts, not amounts) */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-600">Failed / Abandoned</p>
+              <p className="text-2xl font-bold text-red-600">
+                {(summary.counts?.failed ?? 0) + (summary.counts?.abandoned ?? 0)}
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                {summary.counts?.failed ?? 0} failed · {summary.counts?.abandoned ?? 0} abandoned
               </p>
             </div>
             <div className="h-8 w-8 bg-red-100 rounded-full flex items-center justify-center">
@@ -225,20 +257,17 @@ const AdminPayments = () => {
             </div>
           </div>
         </div>
+      </div>
 
-        {/* Failed Transactions count */}
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-gray-600">Failed / Abandoned</p>
-              <p className="text-2xl font-bold text-red-600">
-                {summary.failed_transactions}
-              </p>
-            </div>
-            <div className="h-8 w-8 bg-red-100 rounded-full flex items-center justify-center">
-              <ArrowDownIcon className="h-5 w-5 text-red-600" />
-            </div>
-          </div>
+      {/* Gateway sub-tiles */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-white rounded-lg border border-gray-200 p-4 text-sm">
+          <p className="text-gray-500">Monicredit</p>
+          <p className="text-lg font-semibold text-gray-900">{summary.by_gateway?.monicredit ?? 0} txns</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-4 text-sm">
+          <p className="text-gray-500">Paystack</p>
+          <p className="text-lg font-semibold text-gray-900">{summary.by_gateway?.paystack ?? 0} txns</p>
         </div>
       </div>
 
@@ -282,6 +311,24 @@ const AdminPayments = () => {
               </div>
             </div>
           </div>
+
+          {/* Gateway filter — separate row, less common toggle */}
+          <div className="mt-3 flex items-center gap-2 text-xs">
+            <span className="text-gray-500">Gateway:</span>
+            {GATEWAY_FILTERS.map((g) => (
+              <button
+                key={g.value}
+                onClick={() => { setActiveGateway(g.value); setCurrentPage(1); }}
+                className={`px-2.5 py-1 rounded-md font-medium transition-colors ${
+                  activeGateway === g.value
+                    ? 'bg-gray-900 text-white'
+                    : 'text-gray-600 hover:bg-gray-100 border border-gray-200'
+                }`}
+              >
+                {g.label}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Transactions Table */}
@@ -300,6 +347,9 @@ const AdminPayments = () => {
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
                   Amount
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Gateway
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Status
@@ -329,6 +379,9 @@ const AdminPayments = () => {
                       <div className="animate-pulse h-4 bg-gray-200 rounded w-20"></div>
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">
+                      <div className="animate-pulse h-5 bg-gray-200 rounded w-20"></div>
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
                       <div className="animate-pulse h-6 bg-gray-200 rounded-full w-16"></div>
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">
@@ -354,6 +407,15 @@ const AdminPayments = () => {
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap font-medium text-gray-900">
                       {formatCurrency(transaction.amount)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                        transaction.payment_gateway === 'monicredit'
+                          ? 'bg-purple-100 text-purple-800'
+                          : 'bg-indigo-100 text-indigo-800'
+                      }`}>
+                        {transaction.payment_gateway || 'paystack'}
+                      </span>
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">
                       {getStatusBadge(transaction.status)}
@@ -407,7 +469,7 @@ const AdminPayments = () => {
                 ))
               ) : (
                 <tr>
-                  <td colSpan="7" className="px-4 py-12 text-center">
+                  <td colSpan="8" className="px-4 py-12 text-center">
                     <DocumentTextIcon className="h-12 w-12 text-gray-400 mx-auto mb-4" />
                     <p className="text-gray-500">No transactions found</p>
                   </td>

--- a/src/services/apiLadipo.js
+++ b/src/services/apiLadipo.js
@@ -6,6 +6,9 @@ export const getLadipoCategories = () =>
 export const getLadipoParts = (params = {}) =>
   api.get('/ladipo/parts', { params }).then((r) => r.data.data);
 
+export const getLadipoPartFacets = (params = {}) =>
+  api.get('/ladipo/parts/facets', { params }).then((r) => r.data.data);
+
 export const getLadipoPartBySlug = (slug) =>
   api.get(`/ladipo/parts/${slug}`).then((r) => r.data.data);
 

--- a/src/services/apiLadipoCategories.js
+++ b/src/services/apiLadipoCategories.js
@@ -322,7 +322,7 @@ export const getLadipoSubcategoryBySlug = async (mainCategorySlug, subcategorySl
 export const getLadipoPartsByCategory = async (
   mainCategorySlug,
   subcategorySlug = null,
-  { page = 1, limit = 12, q, make, model, year } = {}
+  { page = 1, limit = 12, q, make, model, year, ...extra } = {}
 ) => {
   try {
     const result = await getLadipoParts({
@@ -333,6 +333,7 @@ export const getLadipoPartsByCategory = async (
       make,
       model,
       year,
+      ...extra,
     });
 
     const total = result?.total || 0;


### PR DESCRIPTION
## Summary

Admin UX cleanup that pairs with the backend changes in [motoka-backend#21](https://github.com/Dave1604/motoka-backend/pull/21).

### Admin pages
- **AdminOrders / AdminOrderDetails / AdminCarDetails / AdminDashboard** now use canonical DB status values (\`pending|processing|completed|cancelled\`) end-to-end via shared \`STATUS_LABEL\` / \`STATUS_COLOR\` maps. Removes the "Inprogress" typo and the four-layer enum translation (DB → backend → frontend filter → frontend display).
- **AdminPayments dashboard rebuilt**: real "Received / Pending / Failed" tiles in actual ₦, Monicredit/Paystack sub-tiles, Gateway column + filter chips, by-gateway breakdown. Backend now returns aggregate SQL summary instead of streaming the full table.
- **AdminLayout sidebar**: extra top padding (\`pt-8\`) above the Motoka logo so it no longer sits jammed against the top edge.

### Ladipo (pre-existing local work)
- New \`AllCategoriesModal\` + \`FilterSidebar\` components, plus \`Ladipo.jsx\` and \`apiLadipo\`/\`apiLadipoCategories\` updates.

### Payment hook (pre-existing local work)
- \`PaymentOptions\` + \`usePayment\` refinements.

## Test plan

- [x] Local: AdminOrders filter chips send canonical values; status pills display \`New / In Progress / Completed / Cancelled\`
- [x] Local: AdminPayments tiles show real numbers (verified against DB probe: ₦699,500 received, ₦35,000 pending, 118 failed/abandoned, Monicredit 101 vs Paystack 27)
- [x] Local: AdminOrderDetails status badge + completion buttons use canonical values
- [ ] Boss verifies sidebar spacing looks right in prod
- [ ] Boss verifies Payments dashboard numbers + gateway filter work in prod

## Related

- Backend PR: Dave1604/motoka-backend#21 (must merge first for the new \`Payments\` summary shape + gateway filter param to work)