### PR TITLE
feat(payment): stop double-init noise + compact admin Payments + duplicates toggle

### DIFF
--- a/src/features/payment/PaymentOptions.jsx
+++ b/src/features/payment/PaymentOptions.jsx
@@ -130,21 +130,43 @@ export default function PaymentOptions() {
     initializePaymentSession();
   }, [location, navigate]);
 
-  // Handle payment method selection
+  // Handle payment method selection.
+  //
+  // If the user has an active (confirmed but unpaid) init on the current
+  // method, switching means abandoning that pending transaction. Require an
+  // explicit confirm + send a clear cancellation_reason to the backend so the
+  // abandoned row is tagged correctly. Without this, a user clicking Pay,
+  // glancing at the bank details, and switching gateways used to silently
+  // double-init — which is how we ended up with 100+ abandoned rows that look
+  // like gateway failures but are actually user-driven gateway switches.
   const handleMethodSelect = (method) => {
+    if (method === selectedMethod) return;
+    if (isInitializing) return; // a confirm-button click is in-flight; don't race
+
+    const currentRef =
+      paymentSession?.monicredit?.data?.reference ||
+      paymentSession?.monicredit?.data?.orderid ||
+      paymentSession?.paystack?.reference;
+    if (isPaymentMethodConfirmed && currentRef) {
+      const ok = window.confirm(
+        'Switching payment method will cancel your current pending payment. Are you sure?'
+      );
+      if (!ok) return;
+      // Fire-and-forget: backend marks the prior txn abandoned with this reason.
+      abandonPayment(currentRef, 'User switched payment method');
+    }
+
     setSelectedMethod(method);
     setMonicreditFallbackError(null);
-    // Auto-confirm Monicredit if account details already exist in the session
-    // (e.g. user switches back from Paystack after a prior Monicredit init)
+
+    // Auto-confirm Monicredit if account details still exist in the session
+    // (e.g. user switches back from Paystack after a prior Monicredit init).
     const monicreditData = paymentSession?.monicredit?.data;
     const alreadyInitialized =
-      monicreditData?.account_number ||
-      monicreditData?.customer?.account_number;
-    if (method === PAYMENT_METHODS.MONICREDIT && alreadyInitialized) {
-      setIsPaymentMethodConfirmed(true);
-    } else {
-      setIsPaymentMethodConfirmed(false);
-    }
+      monicreditData?.account_number || monicreditData?.customer?.account_number;
+    setIsPaymentMethodConfirmed(
+      method === PAYMENT_METHODS.MONICREDIT && alreadyInitialized
+    );
   };
 
   // Helper function to build payment payload
@@ -412,8 +434,17 @@ export default function PaymentOptions() {
     }
   };
 
-  // Switch to Paystack after Monicredit failure
+  // Switch to Paystack after Monicredit init failure. Abandon any prior
+  // Monicredit reference explicitly so the row gets a clean reason rather
+  // than the implicit "abandoned because re-init landed" cleanup the backend
+  // does. Makes admin Payments noise filterable.
   const handleSwitchToPaystack = () => {
+    const monicreditRef =
+      paymentSession?.monicredit?.data?.reference ||
+      paymentSession?.monicredit?.data?.orderid;
+    if (monicreditRef) {
+      abandonPayment(monicreditRef, 'Monicredit init failed, user switched to Paystack');
+    }
     setMonicreditFallbackError(null);
     setSelectedMethod(PAYMENT_METHODS.PAYSTACK);
     setIsPaymentMethodConfirmed(false);
@@ -772,7 +803,8 @@ export default function PaymentOptions() {
               <button
                 key={method.id}
                 onClick={() => handleMethodSelect(method.id)}
-                className={`w-full rounded-[10px] bg-[#F4F5FC] p-4 text-left transition-all ${selectedMethod === method.id
+                disabled={isInitializing}
+                className={`w-full rounded-[10px] bg-[#F4F5FC] p-4 text-left transition-all disabled:opacity-50 disabled:cursor-not-allowed ${selectedMethod === method.id
                   ? "shadow-sm ring-1 ring-[#2389E3]"
                   : "hover:bg-[#FDF6E8] hover:shadow-sm"
                   }`}

--- a/src/pages/admin/AdminPayments.jsx
+++ b/src/pages/admin/AdminPayments.jsx
@@ -32,6 +32,7 @@ const AdminPayments = () => {
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState('All');
   const [activeGateway, setActiveGateway] = useState('all');
+  const [includeDuplicates, setIncludeDuplicates] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -54,7 +55,7 @@ const AdminPayments = () => {
       return;
     }
     fetchTransactions();
-  }, [activeFilter, activeGateway, currentPage, searchTerm]);
+  }, [activeFilter, activeGateway, includeDuplicates, currentPage, searchTerm]);
 
   const fetchTransactions = async () => {
     try {
@@ -67,6 +68,7 @@ const AdminPayments = () => {
         status: activeFilter === 'All' ? 'all' : activeFilter.toLowerCase(),
         gateway: activeGateway,
         search: searchTerm,
+        ...(includeDuplicates ? { include_duplicates: 'true' } : {}),
       });
 
       const response = await fetch(`${config.getApiBaseUrl()}/admin/transactions?${params}`, {
@@ -312,22 +314,38 @@ const AdminPayments = () => {
             </div>
           </div>
 
-          {/* Gateway filter — separate row, less common toggle */}
-          <div className="mt-3 flex items-center gap-2 text-xs">
-            <span className="text-gray-500">Gateway:</span>
-            {GATEWAY_FILTERS.map((g) => (
-              <button
-                key={g.value}
-                onClick={() => { setActiveGateway(g.value); setCurrentPage(1); }}
-                className={`px-2.5 py-1 rounded-md font-medium transition-colors ${
-                  activeGateway === g.value
-                    ? 'bg-gray-900 text-white'
-                    : 'text-gray-600 hover:bg-gray-100 border border-gray-200'
-                }`}
-              >
-                {g.label}
-              </button>
-            ))}
+          {/* Gateway filter + duplicate noise toggle */}
+          <div className="mt-3 flex items-center justify-between gap-2 text-xs">
+            <div className="flex items-center gap-2">
+              <span className="text-gray-500">Gateway:</span>
+              {GATEWAY_FILTERS.map((g) => (
+                <button
+                  key={g.value}
+                  onClick={() => { setActiveGateway(g.value); setCurrentPage(1); }}
+                  className={`px-2.5 py-1 rounded-md font-medium transition-colors ${
+                    activeGateway === g.value
+                      ? 'bg-gray-900 text-white'
+                      : 'text-gray-600 hover:bg-gray-100 border border-gray-200'
+                  }`}
+                >
+                  {g.label}
+                </button>
+              ))}
+            </div>
+            {/* Duplicate-init filter — off by default hides ~95% of historical
+                abandoned noise (users re-clicking Pay / switching gateways). */}
+            <label
+              className="flex items-center gap-1.5 text-gray-600 cursor-pointer select-none whitespace-nowrap"
+              title="Show abandoned rows from users re-initialising payment (gateway switches, double-clicks)"
+            >
+              <input
+                type="checkbox"
+                checked={includeDuplicates}
+                onChange={(e) => { setIncludeDuplicates(e.target.checked); setCurrentPage(1); }}
+                className="h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              Show duplicates
+            </label>
           </div>
         </div>
 
@@ -336,28 +354,28 @@ const AdminPayments = () => {
           <table className="min-w-full divide-y divide-gray-200 text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap">
                   Transaction ID
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
                   User
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
                   Description
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap">
                   Amount
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
                   Gateway
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
                   Status
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
                   Date
                 </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-3 py-2.5 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
                   Actions
                 </th>
               </tr>
@@ -395,21 +413,25 @@ const AdminPayments = () => {
               ) : transactions.length > 0 ? (
                 transactions.map((transaction) => (
                   <tr key={transaction.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 whitespace-nowrap font-mono text-xs text-gray-700">
+                    <td className="px-3 py-2.5 whitespace-nowrap font-mono text-[11px] text-gray-700">
                       {transaction.transaction_id}
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap text-gray-900">
-                      <div className="font-medium text-xs">{transaction.user?.name || 'N/A'}</div>
-                      <div className="text-gray-400 text-xs">{transaction.user?.email || 'N/A'}</div>
+                    <td className="px-3 py-2.5 max-w-[200px] text-gray-900">
+                      <div className="font-medium text-xs truncate" title={transaction.user?.name || 'N/A'}>
+                        {transaction.user?.name || 'N/A'}
+                      </div>
+                      <div className="text-gray-400 text-[11px] truncate" title={transaction.user?.email || 'N/A'}>
+                        {transaction.user?.email || 'N/A'}
+                      </div>
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap text-gray-700">
+                    <td className="px-3 py-2.5 whitespace-nowrap text-xs text-gray-700">
                       {transaction.payment_description || 'Transaction'}
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap font-medium text-gray-900">
+                    <td className="px-3 py-2.5 whitespace-nowrap font-medium text-xs text-gray-900">
                       {formatCurrency(transaction.amount)}
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
-                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                    <td className="px-3 py-2.5 whitespace-nowrap">
+                      <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${
                         transaction.payment_gateway === 'monicredit'
                           ? 'bg-purple-100 text-purple-800'
                           : 'bg-indigo-100 text-indigo-800'
@@ -417,49 +439,53 @@ const AdminPayments = () => {
                         {transaction.payment_gateway || 'paystack'}
                       </span>
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
+                    <td className="px-3 py-2.5 whitespace-nowrap">
                       {getStatusBadge(transaction.status)}
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap text-gray-500 text-xs">
+                    <td className="px-3 py-2.5 whitespace-nowrap text-gray-500 text-[11px]">
                       {formatDate(transaction.created_at)}
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
-                      <div className="flex items-center gap-2">
+                    <td className="px-3 py-2.5 whitespace-nowrap">
+                      {/* Icon-only actions — keeps row width tight. Each button
+                          carries its full meaning in `title`/tooltip. */}
+                      <div className="flex items-center gap-1">
                         <button
                           onClick={() => handleViewTransaction(transaction.transaction_id)}
-                          className="text-blue-600 hover:text-blue-900 flex items-center gap-1 text-xs font-medium"
+                          className="p-1 rounded text-blue-600 hover:bg-blue-50"
+                          title="View transaction details"
+                          aria-label="View"
                         >
-                          <EyeIcon className="h-3.5 w-3.5" />
-                          View
+                          <EyeIcon className="h-4 w-4" />
                         </button>
                         {(transaction.status === 'pending' || transaction.status === 'approved' || transaction.status === 'abandoned') && (
                           <>
                             <button
                               onClick={() => handleMarkPaid(transaction.transaction_id)}
-                              className={`flex items-center gap-1 text-xs font-medium border rounded px-2 py-0.5 ${
+                              className={`p-1 rounded ${
                                 transaction.status === 'abandoned'
-                                  ? 'text-orange-600 hover:text-orange-800 border-orange-300'
+                                  ? 'text-orange-600 hover:bg-orange-50'
                                   : transaction.status === 'pending'
-                                  ? 'text-green-600 hover:text-green-800 border-green-300'
-                                  : 'text-blue-600 hover:text-blue-800 border-blue-300'
+                                  ? 'text-green-600 hover:bg-green-50'
+                                  : 'text-blue-600 hover:bg-blue-50'
                               }`}
                               title={
                                 transaction.status === 'abandoned'
-                                  ? 'User paid on this abandoned transaction — recover and create order'
+                                  ? 'Recover — user paid this abandoned transaction'
                                   : transaction.status === 'pending'
-                                  ? 'Manually mark this payment as received'
-                                  : 'Create missing order for this payment'
+                                  ? 'Mark paid — manually confirm money received'
+                                  : 'Create missing order for this successful payment'
                               }
+                              aria-label={transaction.status === 'abandoned' ? 'Recover' : 'Mark paid'}
                             >
-                              <CheckCircleIcon className="h-3 w-3" />
-                              {transaction.status === 'abandoned' ? 'Recover' : transaction.status === 'pending' ? 'Mark Paid' : 'Create Order'}
+                              <CheckCircleIcon className="h-4 w-4" />
                             </button>
                             <button
                               onClick={() => handleMarkFailed(transaction.transaction_id)}
-                              className="flex items-center gap-1 text-xs font-medium border rounded px-2 py-0.5 text-red-600 hover:text-red-800 border-red-300"
-                              title="No money received — mark this transaction as failed"
+                              className="p-1 rounded text-red-600 hover:bg-red-50"
+                              title="Mark failed — no money was received"
+                              aria-label="Mark failed"
                             >
-                              Failed
+                              <XMarkIcon className="h-4 w-4" />
                             </button>
                           </>
                         )}


### PR DESCRIPTION
## Summary

Pairs with the backend PR adding \`cancellation_reason\` ([Dave1604/motoka-backend#22](https://github.com/Dave1604/motoka-backend/pull/22)).

### User-facing pay flow — root cause fix for the abandoned-txn noise

DB audit showed 95% of all abandoned/failed Monicredit txns come from users clicking Pay multiple times or toggling between Monicredit and Paystack while a virtual account was already provisioned. Three surgical changes to \`PaymentOptions.jsx\`:

- **\`handleMethodSelect\`**: if the user already confirmed an init on the current gateway, switching now requires explicit confirm + abandons the prior reference with a clear reason ('User switched payment method').
- **\`handleSwitchToPaystack\`**: the "Pay via Paystack instead" fallback button explicitly abandons the failed Monicredit ref first.
- **Gateway picker tiles** get \`disabled={isInitializing}\` so rage-clicks can't race the in-flight Confirm button.

The reason strings from the frontend get mapped to canonical \`cancellation_reason\` values on the backend, which the admin Payments filter uses to hide noise by default.

### Admin Payments — compact layout + duplicates toggle

- **Icon-only action buttons** (View / Recover / Mark-Failed) with full tooltips. Saves ~150px per row so the table fits without horizontal scroll on standard admin viewports.
- **"Show duplicates"** checkbox in the gateway filter row. Off by default — table shows ~29 real txns instead of ~128. Toggle on to see the historical noise.
- Tighter padding + smaller font across the table; long emails truncate with hover-tooltips.

## Test plan

- [x] Local: switching gateways after init shows the confirm dialog
- [x] Local: gateway tiles disabled during init
- [x] Local: admin Payments default view shows 29 rows; toggle shows 128
- [x] Local: icon buttons + tooltips on Action column
- [x] Tomtiko04 staging deploys this PR
- [x] Boss verifies the new layout + that admin Payments is calm

## Related

- Backend PR: Dave1604/motoka-backend#22 (must deploy first — frontend expects \`?include_duplicates=\` query param + the cancellation_reason write paths)