### PR TITLE
feat: inline phone prompt for Monicredit (bank transfer) checkout

### DIFF
--- a/src/features/payment/PaymentOptions.jsx
+++ b/src/features/payment/PaymentOptions.jsx
@@ -15,6 +15,8 @@ import { payLadipoOrder, verifyLadipoPayment } from "../../services/apiLadipo";
 import useCartStore from "../../store/cartStore";
 import { useLadipoPaymentModalStore } from "../../store/ladipoPaymentModalStore";
 import AutoRenewalPrompt from "./components/AutoRenewalPrompt";
+import PhonePromptModal from "./components/PhonePromptModal";
+import { useProfile } from "../settings/hooks/useProfile";
 
 const paymentMethods = [
   { id: PAYMENT_METHODS.PAYSTACK, label: "Pay Via Paystack", icon: "💳" },
@@ -35,6 +37,11 @@ export default function PaymentOptions() {
   const [monicreditFallbackError, setMonicreditFallbackError] = useState(null);
   const clearLadipoCart = useCartStore((s) => s.clearCart);
   const [showAutoRenewal, setShowAutoRenewal] = useState(false);
+  // Inline phone capture when Monicredit (bank transfer) needs a phone number
+  const [showPhonePrompt, setShowPhonePrompt] = useState(false);
+  const [phoneSaving, setPhoneSaving] = useState(false);
+  const [phoneError, setPhoneError] = useState(null);
+  const { updateUserProfile } = useProfile();
 
   // For Monicredit
   const customer = paymentSession?.monicredit?.data?.customer;
@@ -423,8 +430,15 @@ export default function PaymentOptions() {
       console.error("Payment initialization error:", err);
       const errMsg = err.response?.data?.message || err.message || 'Failed to initialize payment';
 
-      // When Monicredit fails, offer the user a clear path to switch to card payment
-      if (selectedMethod === PAYMENT_METHODS.MONICREDIT) {
+      // Monicredit (bank transfer) requires a phone number to generate the
+      // virtual account. If that's the reason it failed, prompt for the phone
+      // inline and retry — rather than dumping the user out to Settings.
+      const needsPhone = /phone number is required/i.test(errMsg);
+      if (selectedMethod === PAYMENT_METHODS.MONICREDIT && needsPhone) {
+        setPhoneError(null);
+        setShowPhonePrompt(true);
+      } else if (selectedMethod === PAYMENT_METHODS.MONICREDIT) {
+        // Any other Monicredit failure: offer a clear path to switch to card
         setMonicreditFallbackError(errMsg);
       } else {
         toast.error(errMsg);
@@ -448,6 +462,28 @@ export default function PaymentOptions() {
     setMonicreditFallbackError(null);
     setSelectedMethod(PAYMENT_METHODS.PAYSTACK);
     setIsPaymentMethodConfirmed(false);
+  };
+
+  // Save the phone number the user entered, then retry the Monicredit init so
+  // they stay in the checkout flow instead of being sent off to Settings.
+  const handleSavePhoneAndRetry = async (phone) => {
+    setPhoneSaving(true);
+    setPhoneError(null);
+    try {
+      const res = await updateUserProfile({ phone_number: phone });
+      if (res && res.success) {
+        setShowPhonePrompt(false);
+        await handleConfirmPaymentMethod();
+      } else {
+        setPhoneError(res?.message || "Could not save your phone number. Please try again.");
+      }
+    } catch (err) {
+      setPhoneError(
+        err.response?.data?.message || err.message || "Could not save your phone number. Please try again.",
+      );
+    } finally {
+      setPhoneSaving(false);
+    }
   };
 
   // Note: Monicredit doesn't require a separate payment initiation step
@@ -770,6 +806,17 @@ export default function PaymentOptions() {
 
   return (
     <>
+      <PhonePromptModal
+        open={showPhonePrompt}
+        saving={phoneSaving}
+        error={phoneError}
+        onSubmit={handleSavePhoneAndRetry}
+        onUseCard={() => {
+          setShowPhonePrompt(false);
+          handleSwitchToPaystack();
+        }}
+        onClose={() => setShowPhonePrompt(false)}
+      />
       {showAutoRenewal && (
         <AutoRenewalPrompt
           carSlug={paymentSession?.car_slug}

--- a/src/features/payment/components/PhonePromptModal.jsx
+++ b/src/features/payment/components/PhonePromptModal.jsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+
+// Nigerian mobile: 080..., 070..., 090..., 081... (11 digits) or +234 / 234 prefix.
+const NG_PHONE_RE = /^(?:\+?234|0)[789]\d{9}$/;
+
+const normalize = (raw) => (raw || "").replace(/[\s-]/g, "");
+
+/**
+ * Shown when a Monicredit (bank-transfer) init fails because the user has no
+ * phone number on file. Lets them add it inline and continue, rather than being
+ * bounced to Settings → Profile and losing the checkout. Falls back to card.
+ */
+export default function PhonePromptModal({
+  open,
+  onSubmit,
+  onUseCard,
+  onClose,
+  saving = false,
+  error = null,
+}) {
+  const [phone, setPhone] = useState("");
+  const [localError, setLocalError] = useState(null);
+
+  if (!open) return null;
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const value = normalize(phone);
+    if (!NG_PHONE_RE.test(value)) {
+      setLocalError("Enter a valid Nigerian phone number, e.g. 08012345678.");
+      return;
+    }
+    setLocalError(null);
+    onSubmit(value);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="phone-prompt-title"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <h2
+          id="phone-prompt-title"
+          className="text-lg font-semibold text-[#05243F]"
+        >
+          Add your phone number
+        </h2>
+        <p className="mt-2 text-sm text-[#05243F]/60">
+          Bank transfer needs a phone number to generate your account details.
+          Add it once and we&apos;ll continue your payment right away.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <input
+            type="tel"
+            inputMode="tel"
+            autoFocus
+            placeholder="e.g. 08012345678"
+            value={phone}
+            onChange={(e) => {
+              setPhone(e.target.value);
+              if (localError) setLocalError(null);
+            }}
+            disabled={saving}
+            className="block w-full rounded-lg bg-[#F9FAFC] px-4 py-3 text-sm text-[#05243F] placeholder:text-[#05243F]/40 focus:bg-[#FFF4DD] focus:outline-none transition-all duration-200 disabled:opacity-60"
+          />
+
+          {(localError || error) && (
+            <p className="text-xs text-red-600">{localError || error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={saving}
+            className="w-full rounded-3xl bg-[#2389E3] px-4 py-2.5 text-base font-semibold text-white transition-all duration-300 hover:bg-[#1B6FB8] active:scale-95 disabled:opacity-70 disabled:cursor-not-allowed"
+          >
+            {saving ? "Saving…" : "Save & continue"}
+          </button>
+        </form>
+
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <button
+            type="button"
+            onClick={onUseCard}
+            disabled={saving}
+            className="font-medium text-[#2389E3] hover:underline disabled:opacity-60"
+          >
+            Pay with card instead
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="text-[#05243F]/50 hover:text-[#05243F] disabled:opacity-60"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem
Bank transfer (Monicredit) can't generate a virtual account without a phone number. Users with no phone on file hit a hard error at checkout — "A phone number is required… add it in Settings → Profile" — and most abandon rather than leaving checkout to update their profile. ~21% of active profiles currently have no phone number.

## Fix
When a Monicredit init fails for the phone-required reason, show an **inline modal** that:
- captures the phone number (with Nigerian-format validation),
- saves it to the profile via the existing `PUT /settings/profile` (partial update — other fields untouched),
- **automatically retries** the Monicredit init so the user stays in the flow.

Secondary action falls back to **Pay with card instead** (reuses the existing Paystack-switch handler). Any other Monicredit failure keeps the existing card-fallback banner.

## Scope
- New: `src/features/payment/components/PhonePromptModal.jsx`
- Wired into `src/features/payment/PaymentOptions.jsx` (catch-block detection + save-and-retry + render)
- No backend changes. Reuses `useProfile().updateUserProfile`.

## Verification
- `npm run build` ✓ (compiles clean)
- eslint: 0 new errors introduced (pre-existing dead card-form lint untouched)
- Full browser E2E (phone-less user → modal → save → retry succeeds) pending on request