### PR TITLE
feat(wallet): wallet UI (fund + pay) + dashboard balance pill + DL resume CTA

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,8 @@ import Garage from "./features/garage/Garage.jsx";
 import Licenses from "./features/licenses/Licenses.jsx";
 import PaymentOptions from "./features/payment/PaymentOptions.jsx";
 import PaystackCallback from "./pages/PaystackCallback.jsx";
+import Wallet from "./features/wallet/Wallet.jsx";
+import WalletCallback from "./pages/WalletCallback.jsx";
 import VehiclePaper from "./features/licenses/VehiclePaper.jsx";
 import ConfirmRequest from "./components/shared/ConfirmRequest.jsx";
 import DriversLicense from "./features/licenses/driverslicense/DriversLicense.jsx";
@@ -255,6 +257,8 @@ export default function App() {
             <Route path="documents" element={<CarDocuments />} />
             <Route path="notification" element={<Notification />} />
             <Route path="garage" element={<Garage />} />
+            <Route path="wallet" element={<Wallet />} />
+            <Route path="wallet/callback" element={<WalletCallback />} />
             <Route path="traffic-rules" element={<TrafficRules />} />
             <Route
               path="payment"

--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -18,6 +18,7 @@ import Mo from "../features/mo/Mo.jsx";
     { name: "Dashboard", path: "/dashboard" },
     { name: "Licenses", path: "/licenses" },
     { name: "Garage", path: "/garage" },
+    { name: "Wallet", path: "/wallet" },
     { name: "Ladipo", path: "/ladipo" },
     // { name: "Traffic Rules", path: "/traffic-rules" },
     { name: "Settings", path: "/settings" },

--- a/src/components/WelcomeSection.jsx
+++ b/src/components/WelcomeSection.jsx
@@ -69,14 +69,20 @@
 
 import React, { useState, useEffect } from "react";
 import { Icon } from "@iconify/react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { formatCurrency } from "../utils/formatCurrency";
+import { getWallet } from "../services/apiWallet";
 
 export default function WelcomeSection({ userName }) {
+  const navigate = useNavigate();
   const [showBalance, setShowBalance] = useState(() => {
     const savedState = localStorage.getItem("showBalance");
     return savedState !== null ? JSON.parse(savedState) : true;
   });
-  const balance = 0;
+
+  const { data: wallet } = useQuery({ queryKey: ["wallet"], queryFn: getWallet });
+  const balance = wallet ? Number(wallet.balance_kobo || 0) / 100 : 0;
 
   useEffect(() => {
     localStorage.setItem("showBalance", JSON.stringify(showBalance));
@@ -104,35 +110,37 @@ export default function WelcomeSection({ userName }) {
         </div>
       </div>
 
-      {/* <div className="flex items-center gap-2 sm:gap-4">
+      {/* Wallet balance pill → tap to open the wallet */}
+      <div className="flex items-center gap-2 sm:gap-4">
         <span className="hidden text-base font-normal text-[#05243F]/44 sm:block sm:text-sm">
           Wallet Balance
         </span>
-        <div className="flex cursor-pointer items-center gap-2 rounded-full bg-white px-3 py-1.5 text-sm sm:gap-3 sm:px-4 sm:py-2">
-          <span onClick={() => setShowBalance(!showBalance)}>
+        <div className="flex items-center gap-2 rounded-full bg-white px-3 py-1.5 text-sm shadow-sm sm:gap-3 sm:px-4 sm:py-2">
+          <button
+            type="button"
+            aria-label={showBalance ? "Hide balance" : "Show balance"}
+            onClick={() => setShowBalance((s) => !s)}
+            className="flex items-center"
+          >
             {showBalance ? (
               <Icon icon="mingcute:eye-fill" fontSize={20} color="#697C8C" />
             ) : (
               <Icon icon="majesticons:eye-off" fontSize={20} color="#697C8C" />
             )}
-          </span>
-          <span
-            className={`text-lg font-semibold text-[#2389E3] transition-opacity duration-300 ease-in-out sm:text-base ${
-              showBalance ? "opacity-100" : "opacity-70"
-            }`}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate("/wallet")}
+            className="text-lg font-semibold text-[#2389E3] transition-opacity duration-300 ease-in-out hover:opacity-80 sm:text-base"
           >
             {showBalance ? (
               formatCurrency(balance)
             ) : (
-              <Icon
-                icon="mdi:shield-lock-outline"
-                fontSize={20}
-                color="#2389E3"
-              />
+              <Icon icon="mdi:shield-lock-outline" fontSize={20} color="#2389E3" />
             )}
-          </span>
+          </button>
         </div>
-      </div> */}
+      </div>
     </div>
   );
 }

--- a/src/features/licenses/driverslicense/DriverLicenseOrderSummary.jsx
+++ b/src/features/licenses/driverslicense/DriverLicenseOrderSummary.jsx
@@ -109,6 +109,15 @@ export default function DriverLicenseOrderSummary() {
         </h1>
       </div>
 
+      {/* Reassurance: the application is already saved, so users can pay now or
+          come back later without losing their details. */}
+      <div className="mb-6 flex items-start gap-3 rounded-[16px] border border-[#1FA97A]/20 bg-[#E7F6EF] px-5 py-4">
+        <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#1FA97A] text-white">✓</span>
+        <p className="text-sm text-[#05243F]/80">
+          <span className="font-semibold text-[#05243F]">Application submitted.</span> Your details are saved — complete payment to process it. You can leave and come back to pay anytime.
+        </p>
+      </div>
+
       <div className="mb-6 rounded-[20px] border border-[#E1E5EE] bg-white p-6 shadow-sm">
         <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-[#05243F]/40">
           Order Details

--- a/src/features/licenses/driverslicense/DriversLicense.jsx
+++ b/src/features/licenses/driverslicense/DriversLicense.jsx
@@ -39,6 +39,9 @@ export default function DriversLicense() {
   const [licenseType, setLicenseType] = useState("new");
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Previously-submitted applications (for the "continue to payment" resume CTA).
+  const [newAppData, setNewAppData] = useState(null);
+  const [renewAppData, setRenewAppData] = useState(null);
 
   // New license state
   const [newForm, setNewForm] = useState({});
@@ -82,6 +85,36 @@ export default function DriversLicense() {
 
   const currentPrice = licenseType === "new" ? priceNew : priceRenew;
 
+  // A returning applicant who submitted the form but hasn't paid yet can jump
+  // straight back to payment — we already saved their details.
+  const activeApp = licenseType === "new" ? newAppData : renewAppData;
+  const canResume = activeApp?.status === "submitted" && !activeApp?.order_id;
+
+  const handleResume = () => {
+    if (licenseType === "new") {
+      navigate("/licenses/drivers-license/order-summary", {
+        state: {
+          license_type: "new",
+          duration: selectedNewDuration,
+          price: priceNew,
+          formData: { ...newForm, passport_photo_url: activeApp?.passport_photo_url || passportPreview },
+        },
+      });
+    } else {
+      navigate("/licenses/drivers-license/order-summary", {
+        state: {
+          license_type: "renew",
+          duration: selectedRenewDuration,
+          price: priceRenew,
+          licenseNumber,
+          dateOfBirth,
+          dateOfExpiry,
+          license_document_url: licenseDocUrl,
+        },
+      });
+    }
+  };
+
   useEffect(() => {
     const load = async () => {
       try {
@@ -90,6 +123,9 @@ export default function DriversLicense() {
           getDriverLicenseApplication("renew").catch(() => null),
           getDriverLicenseDocuments().catch(() => []),
         ]);
+
+        setNewAppData(newApp);
+        setRenewAppData(renewApp);
 
         if (newApp) {
           const vals = {};
@@ -290,6 +326,23 @@ export default function DriversLicense() {
 
         {/* Center: form fields */}
         <div className="scrollbar-thin scrollbar-track-[#F5F6FA] scrollbar-thumb-[#2389E3] hover:scrollbar-thumb-[#2389E3]/80 scrollbar-thumb-rounded-full h-[calc(100vh-300px)] overflow-y-auto pr-4">
+          {canResume && (
+            <div className="mb-4 flex flex-col gap-3 rounded-2xl border border-[#2389E3]/20 bg-[#EAF4FD] p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-[#05243F]">Continue where you left off</p>
+                <p className="text-xs text-[#05243F]/60">
+                  We've saved your application details. You just need to complete payment.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleResume}
+                className="shrink-0 rounded-full bg-[#2389E3] px-5 py-2.5 text-sm font-semibold text-white transition-all hover:bg-[#1b6dbd] active:scale-[0.98]"
+              >
+                Continue to payment
+              </button>
+            </div>
+          )}
           {licenseType === "new" ? (
             <div className="space-y-4">
               {/* Passport upload */}

--- a/src/features/licenses/driverslicense/DriversLicense.jsx
+++ b/src/features/licenses/driverslicense/DriversLicense.jsx
@@ -220,6 +220,8 @@ export default function DriversLicense() {
           status: "submitted",
         });
 
+        toast.success("Application submitted — your details are saved. Complete payment to process it.", { duration: 5000 });
+
         navigate("/licenses/drivers-license/order-summary", {
           state: {
             license_type: "new",
@@ -251,6 +253,8 @@ export default function DriversLicense() {
           license_document_url: docUrl,
           status: "submitted",
         });
+
+        toast.success("Application submitted — your details are saved. Complete payment to process it.", { duration: 5000 });
 
         navigate("/licenses/drivers-license/order-summary", {
           state: {
@@ -518,7 +522,7 @@ export default function DriversLicense() {
             disabled={isSubmitting}
             className="mt-6 flex w-full items-center justify-center gap-2 rounded-full bg-[#2284DB] py-4 text-base font-semibold text-white shadow-md transition-all hover:bg-[#1a6bb8] disabled:opacity-60"
           >
-            {isSubmitting ? "Saving..." : "Confirm and Proceed"}
+            {isSubmitting ? "Submitting..." : "Submit application"}
             <Icon icon="mdi:arrow-right" className="text-lg" />
           </button>
         </div>

--- a/src/features/payment/PaymentOptions.jsx
+++ b/src/features/payment/PaymentOptions.jsx
@@ -11,6 +11,7 @@ import { usePaymentVerification } from "./hooks/usePayment";
 import { initializePaystackPayment } from "../../services/apiPaystack";
 import { initiateMonicreditPayment } from "../../services/apiMonicredit";
 import { abandonPayment } from "../../services/apiPayment";
+import { getWallet, payFromWallet } from "../../services/apiWallet";
 import { payLadipoOrder, verifyLadipoPayment } from "../../services/apiLadipo";
 import useCartStore from "../../store/cartStore";
 import { useLadipoPaymentModalStore } from "../../store/ladipoPaymentModalStore";
@@ -35,6 +36,15 @@ export default function PaymentOptions() {
   const [monicreditFallbackError, setMonicreditFallbackError] = useState(null);
   const clearLadipoCart = useCartStore((s) => s.clearCart);
   const [showAutoRenewal, setShowAutoRenewal] = useState(false);
+  const [wallet, setWallet] = useState(null);
+  const [walletPaying, setWalletPaying] = useState(false);
+
+  // Load wallet balance so we can offer "pay from wallet" on car renewals.
+  useEffect(() => {
+    let alive = true;
+    getWallet().then((w) => { if (alive) setWallet(w); }).catch(() => {});
+    return () => { alive = false; };
+  }, []);
 
   // For Monicredit
   const customer = paymentSession?.monicredit?.data?.customer;
@@ -54,6 +64,25 @@ export default function PaymentOptions() {
   const paystackAmount = paymentSession?.paystack?.reference
     ? Number(paymentSession?.amount || 0) / 100
     : Number(paymentSession?.price || paymentSession?.amount || 0);
+
+  // ── Pay-from-wallet (car renewals only; /wallet/pay prices renewals) ────────
+  const isRenewalPayment =
+    paymentSession?.type === PAYMENT_TYPES.LICENSE_RENEWAL ||
+    paymentSession?.type === PAYMENT_TYPES.VEHICLE_PAPER;
+  const fmtN = (n) => `₦${Number(n || 0).toLocaleString("en-NG", { maximumFractionDigits: 2 })}`;
+  const renewalCostNaira = Number(totalAmount || paystackAmount || 0);
+  const walletBalanceNaira = wallet ? Number(wallet.balance_kobo || 0) / 100 : 0;
+  const walletEligible = isRenewalPayment && !!wallet && wallet.status !== "frozen";
+  const walletSufficient = walletEligible && renewalCostNaira > 0 && walletBalanceNaira >= renewalCostNaira;
+  const walletDetails = {
+    availableBalance: fmtN(walletBalanceNaira),
+    renewalCost: fmtN(renewalCostNaira),
+    newBalance: fmtN(Math.max(0, walletBalanceNaira - renewalCostNaira)),
+  };
+  // Offer wallet first on eligible renewals (matches the payment-options design).
+  const methodsToShow = walletEligible
+    ? [{ id: PAYMENT_METHODS.WALLET, label: `Wallet Balance: ${fmtN(walletBalanceNaira)}` }, ...paymentMethods]
+    : paymentMethods;
 
   const { verifyMonicredit, verifyPaystack } = usePaymentVerification();
 
@@ -450,6 +479,32 @@ export default function PaymentOptions() {
     setIsPaymentMethodConfirmed(false);
   };
 
+  // Pay for the renewal from wallet balance. The backend debits + creates the
+  // order atomically, so success here means the order exists.
+  const handlePayFromWallet = async () => {
+    if (!walletSufficient || walletPaying) return;
+    setWalletPaying(true);
+    try {
+      const payload = buildPaymentPayload();
+      if (!payload.car_slug) {
+        toast.error("Car information is missing. Please try again.");
+        return;
+      }
+      const result = await payFromWallet(payload);
+      if (result?.order_id) {
+        setWallet((w) => (w ? { ...w, balance_kobo: result.balance_kobo } : w));
+        toast.success("Paid from wallet successfully");
+        navigateAfterPayment({ paymentSuccess: true, paymentMethod: "wallet", reference: result.reference });
+      } else {
+        toast.error("Wallet payment could not be completed.");
+      }
+    } catch (err) {
+      toast.error(err.response?.data?.message || err.message || "Wallet payment failed.");
+    } finally {
+      setWalletPaying(false);
+    }
+  };
+
   // Note: Monicredit doesn't require a separate payment initiation step
   // Users just see bank details and verify after making the transfer
 
@@ -803,7 +858,7 @@ export default function PaymentOptions() {
         <div className="grid grid-cols-1 items-start gap-8 md:grid-cols-[1fr_auto_1fr]">
           {/* LEFT SECTION */}
           <div className="space-y-2">
-            {paymentMethods.map((method) => (
+            {methodsToShow.map((method) => (
               <button
                 key={method.id}
                 onClick={() => handleMethodSelect(method.id)}
@@ -867,9 +922,27 @@ export default function PaymentOptions() {
                     {walletDetails.newBalance}
                   </span>
                 </div>
-                <button className="mt-5 w-full rounded-full bg-[#2284DB] py-3 text-center text-base font-semibold text-white transition-all hover:bg-[#FDF6E8] hover:text-[#05243F] md:mt-10">
-                  N35,000 Pay Now
-                </button>
+                {walletSufficient ? (
+                  <button
+                    onClick={handlePayFromWallet}
+                    disabled={walletPaying}
+                    className="mt-5 w-full rounded-full bg-[#2284DB] py-3 text-center text-base font-semibold text-white transition-all hover:bg-[#1a6fc2] active:scale-[0.99] disabled:opacity-60 md:mt-10"
+                  >
+                    {walletPaying ? "Processing…" : `${walletDetails.renewalCost} Pay Now`}
+                  </button>
+                ) : (
+                  <div className="mt-5 md:mt-10">
+                    <p className="mb-3 text-center text-sm text-[#C0435C]">
+                      Insufficient balance. You need {walletDetails.renewalCost} but have {walletDetails.availableBalance}.
+                    </p>
+                    <button
+                      onClick={() => navigate("/wallet")}
+                      className="w-full rounded-full bg-[#2284DB] py-3 text-center text-base font-semibold text-white transition-all hover:bg-[#1a6fc2]"
+                    >
+                      Top up wallet
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/src/features/payment/config/paymentTypes.js
+++ b/src/features/payment/config/paymentTypes.js
@@ -10,6 +10,7 @@ export const PAYMENT_METHODS = {
   PAYSTACK: 'paystack',
   MONICREDIT: 'monicredit',
   BANK_TRANSFER: 'bank_transfer',
+  WALLET: 'wallet',
 };
 
 export const PAYMENT_CONFIG = {

--- a/src/features/wallet/Wallet.jsx
+++ b/src/features/wallet/Wallet.jsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Plus, ArrowDownLeft, ArrowUpRight, Wallet as WalletIcon, ShieldCheck } from "lucide-react";
+import { getWallet, getWalletLedger } from "../../services/apiWallet";
+import FundWalletModal from "./components/FundWalletModal";
+
+const naira = (kobo) => `₦${(Number(kobo || 0) / 100).toLocaleString("en-NG", { maximumFractionDigits: 2 })}`;
+
+const REASON_LABEL = {
+  funding: "Wallet top-up",
+  payment: "Payment",
+  refund: "Refund",
+  admin_adjustment: "Adjustment",
+  reversal: "Reversal",
+};
+
+export default function Wallet() {
+  const [fundOpen, setFundOpen] = useState(false);
+
+  const { data: wallet, isLoading: walletLoading } = useQuery({
+    queryKey: ["wallet"],
+    queryFn: getWallet,
+  });
+  const { data: ledger, isLoading: ledgerLoading } = useQuery({
+    queryKey: ["wallet-ledger"],
+    queryFn: () => getWalletLedger({ page: 1, limit: 25 }),
+  });
+
+  const entries = ledger?.entries || [];
+
+  return (
+    <div className="mx-auto max-w-2xl px-3 pb-16 sm:px-6">
+      <h1 className="mb-5 text-xl font-medium text-[#05243F] sm:text-2xl">Wallet</h1>
+
+      {/* Balance hero */}
+      <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-[#05243F] to-[#0A3B66] p-6 text-white shadow-sm">
+        <div className="absolute -right-8 -top-8 h-40 w-40 rounded-full bg-white/5" />
+        <div className="absolute -bottom-10 -left-6 h-36 w-36 rounded-full bg-white/5" />
+        <div className="relative">
+          <div className="mb-3 flex items-center gap-2 text-white/70">
+            <WalletIcon className="h-4 w-4" />
+            <span className="text-sm">Available balance</span>
+          </div>
+          <div className="mb-6 text-4xl font-semibold tracking-tight">
+            {walletLoading ? <span className="opacity-50">₦—</span> : naira(wallet?.balance_kobo)}
+          </div>
+          <div className="flex items-center justify-between">
+            <button
+              onClick={() => setFundOpen(true)}
+              className="flex items-center gap-2 rounded-full bg-[#2389E3] px-5 py-2.5 text-sm font-semibold text-white transition-all hover:bg-[#1b6dbd] active:scale-[0.98]"
+            >
+              <Plus className="h-4 w-4" /> Add money
+            </button>
+            {wallet?.status === "frozen" && (
+              <span className="rounded-full bg-red-500/20 px-3 py-1 text-xs font-medium text-red-100">Frozen</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Reassurance strip */}
+      <div className="mt-3 flex items-center gap-2 px-1 text-xs text-[#697C8C]">
+        <ShieldCheck className="h-3.5 w-3.5" />
+        Funds stay in your wallet and can be used for any Motoka renewal.
+      </div>
+
+      {/* History */}
+      <div className="mt-8">
+        <h2 className="mb-3 text-sm font-semibold text-[#05243F]">Transaction history</h2>
+        {ledgerLoading ? (
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => <div key={i} className="h-16 animate-pulse rounded-2xl bg-[#F1F4F9]" />)}
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-[#E1E5EE] p-8 text-center">
+            <p className="text-sm text-[#697C8C]">No transactions yet.</p>
+            <p className="mt-1 text-xs text-[#697C8C]/70">Add money to get started.</p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-[#F1F4F9] overflow-hidden rounded-2xl border border-[#EEF1F6] bg-white">
+            {entries.map((e) => {
+              const credit = e.direction === "credit";
+              return (
+                <li key={e.id} className="flex items-center gap-3 px-4 py-3.5">
+                  <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${credit ? "bg-[#E7F6EF] text-[#1FA97A]" : "bg-[#FDEEF0] text-[#C0435C]"}`}>
+                    {credit ? <ArrowDownLeft className="h-4 w-4" /> : <ArrowUpRight className="h-4 w-4" />}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-[#05243F]">{REASON_LABEL[e.reason] || e.reason}</p>
+                    <p className="text-xs text-[#697C8C]">{new Date(e.created_at).toLocaleString("en-NG", { dateStyle: "medium", timeStyle: "short" })}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className={`text-sm font-semibold ${credit ? "text-[#1FA97A]" : "text-[#05243F]"}`}>
+                      {credit ? "+" : "−"}{naira(e.amount_kobo)}
+                    </p>
+                    <p className="text-[11px] text-[#697C8C]">{naira(e.balance_after)}</p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <FundWalletModal open={fundOpen} onClose={() => setFundOpen(false)} />
+    </div>
+  );
+}

--- a/src/features/wallet/components/FundWalletModal.jsx
+++ b/src/features/wallet/components/FundWalletModal.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { X, Zap, Loader2 } from "lucide-react";
+import { toast } from "react-hot-toast";
+import { getFundingQuote, initFunding } from "../../../services/apiWallet";
+
+const PRESETS = [2000, 5000, 10000, 20000]; // naira
+const naira = (n) => `₦${Number(n || 0).toLocaleString("en-NG", { maximumFractionDigits: 2 })}`;
+
+export default function FundWalletModal({ open, onClose }) {
+  const [amount, setAmount] = useState(5000); // naira
+  const [quote, setQuote] = useState(null);
+  const [quoting, setQuoting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  const debounceRef = useRef();
+
+  // Live, debounced fee quote so the breakdown updates as they type/pick.
+  useEffect(() => {
+    if (!open) return;
+    const kobo = Math.round(Number(amount) * 100);
+    if (!kobo || kobo < 10000) {
+      setQuote(null);
+      setError(amount ? "Minimum top-up is ₦100." : null);
+      return;
+    }
+    setError(null);
+    setQuoting(true);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        setQuote(await getFundingQuote(kobo));
+      } catch (e) {
+        setError(e.response?.data?.message || "Couldn't fetch fee. Try a different amount.");
+        setQuote(null);
+      } finally {
+        setQuoting(false);
+      }
+    }, 350);
+    return () => clearTimeout(debounceRef.current);
+  }, [amount, open]);
+
+  const feePct = useMemo(() => {
+    if (!quote?.credit_kobo) return null;
+    return (quote.fee_kobo / quote.credit_kobo) * 100;
+  }, [quote]);
+
+  if (!open) return null;
+
+  const handleContinue = async () => {
+    const kobo = Math.round(Number(amount) * 100);
+    if (!kobo || kobo < 10000) return setError("Minimum top-up is ₦100.");
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await initFunding(kobo);
+      if (res?.authorization_url) {
+        // Full-tab redirect to Paystack; it returns to /wallet/callback.
+        window.location.href = res.authorization_url;
+      } else {
+        throw new Error("Could not start payment. Please try again.");
+      }
+    } catch (e) {
+      setError(e.response?.data?.message || e.message || "Could not start payment.");
+      toast.error("Could not start payment.");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+      <div className="w-full max-w-md rounded-t-3xl bg-white p-6 shadow-xl sm:rounded-3xl">
+        <div className="mb-1 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-[#05243F]">Add money</h2>
+          <button onClick={onClose} className="rounded-full p-1 text-[#697C8C] hover:bg-[#E1E5EE]">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* The honest hook: pay the fee once, then spend fee-free. */}
+        <div className="mb-4 flex items-start gap-2 rounded-2xl bg-[#FFF4DD] px-4 py-3">
+          <Zap className="mt-0.5 h-4 w-4 shrink-0 text-[#E0A200]" />
+          <p className="text-xs leading-relaxed text-[#05243F]/80">
+            Pay the card fee <span className="font-semibold">once</span> when you top up — then every renewal you pay from your wallet is instant and <span className="font-semibold">fee-free</span>.
+          </p>
+        </div>
+
+        {/* Preset chips */}
+        <div className="mb-4 grid grid-cols-4 gap-2">
+          {PRESETS.map((p) => (
+            <button
+              key={p}
+              onClick={() => setAmount(p)}
+              className={`relative rounded-xl py-2.5 text-sm font-semibold transition-all ${
+                Number(amount) === p
+                  ? "bg-[#2389E3] text-white"
+                  : "bg-[#F1F4F9] text-[#05243F] hover:bg-[#E1E5EE]"
+              }`}
+            >
+              ₦{(p / 1000)}k
+              {p >= 10000 && (
+                <span className="absolute -top-2 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-[#1FA97A] px-1.5 py-0.5 text-[9px] font-bold text-white">
+                  best value
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* Custom amount */}
+        <label className="mb-1.5 block text-xs font-medium text-[#697C8C]">Or enter an amount</label>
+        <div className="relative mb-4">
+          <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#05243F]">₦</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={100}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            disabled={submitting}
+            className="block w-full rounded-xl bg-[#F9FAFC] py-3 pl-8 pr-4 text-base font-semibold text-[#05243F] focus:bg-[#FFF4DD] focus:outline-none"
+          />
+        </div>
+
+        {/* Live breakdown */}
+        <div className="mb-4 rounded-2xl border border-[#EEF1F6] p-4 text-sm">
+          <Row label="Added to wallet" value={quote ? naira(quote.credit_naira) : "—"} />
+          <Row
+            label={<span>Processing fee {feePct != null && <span className="text-[#697C8C]">({feePct.toFixed(1)}%)</span>}</span>}
+            value={quoting ? "…" : quote ? naira(quote.fee_naira) : "—"}
+            muted
+          />
+          <div className="my-2 border-t border-dashed border-[#EEF1F6]" />
+          <Row label={<span className="font-semibold text-[#05243F]">You pay</span>} value={<span className="font-semibold text-[#05243F]">{quote ? naira(quote.total_charge_naira) : "—"}</span>} big />
+        </div>
+
+        {error && <p className="mb-3 text-xs text-red-600">{error}</p>}
+
+        <button
+          onClick={handleContinue}
+          disabled={submitting || quoting || !quote}
+          className="flex w-full items-center justify-center gap-2 rounded-3xl bg-[#2389E3] px-4 py-3 text-base font-semibold text-white transition-all hover:bg-[#1b6dbd] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? <><Loader2 className="h-4 w-4 animate-spin" /> Redirecting…</> : <>Continue to pay {quote ? naira(quote.total_charge_naira) : ""}</>}
+        </button>
+        <p className="mt-3 text-center text-[11px] text-[#697C8C]">Secured by Paystack · Card payment</p>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value, muted, big }) {
+  return (
+    <div className={`flex items-center justify-between ${big ? "" : "py-0.5"}`}>
+      <span className={muted ? "text-[#697C8C]" : "text-[#05243F]/80"}>{label}</span>
+      <span className={muted ? "text-[#697C8C]" : "text-[#05243F]"}>{value}</span>
+    </div>
+  );
+}

--- a/src/features/wallet/components/FundWalletModal.jsx
+++ b/src/features/wallet/components/FundWalletModal.jsx
@@ -109,7 +109,7 @@ export default function FundWalletModal({ open, onClose }) {
         {/* Custom amount */}
         <label className="mb-1.5 block text-xs font-medium text-[#697C8C]">Or enter an amount</label>
         <div className="relative mb-4">
-          <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#05243F]">₦</span>
+          <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-base font-semibold text-[#05243F]">₦</span>
           <input
             type="number"
             inputMode="numeric"
@@ -117,7 +117,7 @@ export default function FundWalletModal({ open, onClose }) {
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             disabled={submitting}
-            className="block w-full rounded-xl bg-[#F9FAFC] py-3 pl-8 pr-4 text-base font-semibold text-[#05243F] focus:bg-[#FFF4DD] focus:outline-none"
+            className="block w-full rounded-xl bg-[#F9FAFC] py-3 pl-10 pr-4 text-base font-semibold text-[#05243F] focus:bg-[#FFF4DD] focus:outline-none"
           />
         </div>
 

--- a/src/pages/WalletCallback.jsx
+++ b/src/pages/WalletCallback.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import { verifyPaystackPayment } from "../services/apiPaystack";
+
+// Paystack redirects here after a wallet top-up. Verifying the reference is what
+// credits the wallet on the backend (the verify path handles wallet_funding).
+export default function WalletCallback() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [state, setState] = useState("verifying"); // verifying | success | error
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    const reference = params.get("reference") || params.get("trxref");
+    if (!reference) {
+      setState("error");
+      return;
+    }
+    verifyPaystackPayment(reference)
+      .then(() => {
+        setState("success");
+        queryClient.invalidateQueries({ queryKey: ["wallet"] });
+        queryClient.invalidateQueries({ queryKey: ["wallet-ledger"] });
+        setTimeout(() => navigate("/wallet", { replace: true }), 1600);
+      })
+      .catch(() => {
+        setState("error");
+        setTimeout(() => navigate("/wallet", { replace: true }), 2200);
+      });
+  }, [params, navigate, queryClient]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
+      {state === "verifying" && (
+        <>
+          <Loader2 className="h-10 w-10 animate-spin text-[#2389E3]" />
+          <p className="mt-4 text-sm text-[#697C8C]">Confirming your top-up…</p>
+        </>
+      )}
+      {state === "success" && (
+        <>
+          <CheckCircle2 className="h-12 w-12 text-[#1FA97A]" />
+          <p className="mt-4 text-lg font-semibold text-[#05243F]">Wallet funded</p>
+          <p className="mt-1 text-sm text-[#697C8C]">Taking you back to your wallet…</p>
+        </>
+      )}
+      {state === "error" && (
+        <>
+          <XCircle className="h-12 w-12 text-[#C0435C]" />
+          <p className="mt-4 text-lg font-semibold text-[#05243F]">We couldn't confirm that payment</p>
+          <p className="mt-1 text-sm text-[#697C8C]">If you were charged, your wallet will update shortly. Redirecting…</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/AdminDriverLicenseApplications.jsx
+++ b/src/pages/admin/AdminDriverLicenseApplications.jsx
@@ -351,7 +351,7 @@ export default function AdminDriverLicenseApplications() {
             <table className="min-w-full divide-y divide-gray-100">
               <thead className="bg-gray-50">
                 <tr>
-                  {['Applicant', 'Type', 'Status', 'Linked Order', 'Submitted', 'Actions'].map(h => (
+                  {['Applicant', 'Type', 'Status', 'Payment', 'Submitted', 'Actions'].map(h => (
                     <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
                       {h}
                     </th>
@@ -371,9 +371,15 @@ export default function AdminDriverLicenseApplications() {
                     <td className="px-4 py-3">
                       <StatusBadge status={app.status} />
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-500">
+                    <td className="px-4 py-3 text-sm">
                       {app.renewal_orders ? (
-                        <span className="text-[#2284DB] font-medium">#{app.renewal_orders.id}</span>
+                        <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-800">
+                          Paid · #{app.renewal_orders.id}
+                        </span>
+                      ) : app.status === 'submitted' ? (
+                        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+                          Awaiting payment
+                        </span>
                       ) : (
                         <span className="text-gray-300">—</span>
                       )}

--- a/src/services/apiWallet.js
+++ b/src/services/apiWallet.js
@@ -1,0 +1,25 @@
+import { api } from "./apiClient";
+
+// Wallet balance + status.
+export async function getWallet() {
+  const { data } = await api.get("/wallet");
+  return data?.data ?? data;
+}
+
+// Paginated ledger (transaction history).
+export async function getWalletLedger({ page = 1, limit = 20 } = {}) {
+  const { data } = await api.get("/wallet/ledger", { params: { page, limit } });
+  return data?.data ?? data;
+}
+
+// Transparent fee breakdown for a desired top-up (kobo in, breakdown out).
+export async function getFundingQuote(amountKobo) {
+  const { data } = await api.get("/wallet/fund/quote", { params: { amount_kobo: amountKobo } });
+  return data?.data ?? data;
+}
+
+// Start a top-up. Returns { authorization_url, reference, credit_kobo, fee_kobo, total_charge_kobo }.
+export async function initFunding(amountKobo) {
+  const { data } = await api.post("/wallet/fund", { amount_kobo: amountKobo });
+  return data?.data ?? data;
+}

--- a/src/services/apiWallet.js
+++ b/src/services/apiWallet.js
@@ -23,3 +23,11 @@ export async function initFunding(amountKobo) {
   const { data } = await api.post("/wallet/fund", { amount_kobo: amountKobo });
   return data?.data ?? data;
 }
+
+// Pay for a car renewal from wallet balance. `payload` mirrors the renewal init
+// payload (car_slug, payment_schedule_id, renewal_months, delivery_details,
+// renewal_state). Returns { order_id, order_number, balance_kobo }.
+export async function payFromWallet(payload) {
+  const { data } = await api.post("/wallet/pay", payload);
+  return data?.data ?? data;
+}


### PR DESCRIPTION
Frontend for the wallet Phase 1 (funding). Pairs with backend PR Dave1604/motoka-backend#29.

## What
- **Wallet page** (`/wallet`): gradient balance hero, Add-money CTA, and a clean ledger/transaction history with credit/debit styling.
- **Add-money modal**: preset chips (₦2k/₦5k/₦10k/₦20k with 'best value' badges), custom amount, and a **live, transparent fee breakdown** (added-to-wallet + processing fee = you pay) fetched from `/wallet/fund/quote`. Framing nudges larger top-ups: 'pay the card fee once, then every wallet payment is fee-free.'
- **Funding flow**: redirects to Paystack, returns via `/wallet/callback` which verifies and credits.
- Adds **Wallet** to the main nav.

## Verified end-to-end (test mode)
Login → Wallet → Add ₦5,000 → Paystack test checkout (charged the correct gross ₦5,177.67) → callback → **wallet credited ₦5,000**, transaction shows in history. Screenshots on request.

## Notes
- Feature is gated server-side by `WALLET_ENABLED`; the page/nav can be flag-gated on the frontend too if you prefer a staged rollout.
- Fee handling: user covers Paystack's fee via gross-up (agreed), so the amount they pick lands in the wallet exactly.