### PR TITLE
chore(wallet): funding label — card, bank transfer or USSD

### DIFF
--- a/src/features/wallet/components/FundWalletModal.jsx
+++ b/src/features/wallet/components/FundWalletModal.jsx
@@ -142,7 +142,7 @@ export default function FundWalletModal({ open, onClose }) {
         >
           {submitting ? <><Loader2 className="h-4 w-4 animate-spin" /> Redirecting…</> : <>Continue to pay {quote ? naira(quote.total_charge_naira) : ""}</>}
         </button>
-        <p className="mt-3 text-center text-[11px] text-[#697C8C]">Secured by Paystack · Card payment</p>
+        <p className="mt-3 text-center text-[11px] text-[#697C8C]">Secured by Paystack · Card, bank transfer or USSD</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Single follow-up commit to the already-merged wallet UI (#257): updates the fund-modal label now that funding accepts bank transfer + USSD, not just card. Backend change to enable those channels is deployed on main.