### PR TITLE
refactor(ProductsList): simplify layout by removing compact prop

### DIFF
--- a/src/features/ladipo/components/productsList.jsx
+++ b/src/features/ladipo/components/productsList.jsx
@@ -1,12 +1,8 @@
 import ProductCard from "./productCard";
 
-function ProductsList({ parts = [], compact = false }) {
+function ProductsList({ parts = [] }) {
   return (
-    <div
-      className={`grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 sm:gap-3 ${
-        compact ? "lg:grid-cols-3" : "lg:grid-cols-4"
-      }`}
-    >
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 sm:gap-3 lg:grid-cols-3">
       {parts.map((part) => (
         <ProductCard key={part.id} part={part} />
       ))}


### PR DESCRIPTION
Updated the ProductsList component to remove the unused 'compact' prop, simplifying the layout. The grid now defaults to a consistent column structure, enhancing readability and maintainability.c